### PR TITLE
Web 12: standardize PostProps property names to camelCase

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -49,12 +49,12 @@ const Post: React.FC<Props> = ({
         <LongText style={tw`text-gray-500  font-thin`} text={props.postText} />
       )}
 
-      {props?.Media && props.Media.length > 0 && (
+      {props?.media && props.media.length > 0 && (
         <ImageGrid
-          medias={props.Media || []}
+          medias={props.media || []}
           style={tw`mb-2`}
           onImageTouch={(id) => {
-            const index = props.Media?.findIndex(
+            const index = props.media?.findIndex(
               (media) => media?.id === id.toString()
             )
             //@ts-ignore

--- a/src/components/PostHeader.tsx
+++ b/src/components/PostHeader.tsx
@@ -31,7 +31,7 @@ interface PostHeaderProps extends PostProps {
 
 const PostHeader: React.FC<PostHeaderProps> = (props) => {
   const user = useSelector((state: RootState) => state.auth)
-  const PostUser = props.User
+  const PostUser = props.user
   const navigation = useNavigation()
 
   const handlePress = () => {
@@ -55,7 +55,7 @@ const PostHeader: React.FC<PostHeaderProps> = (props) => {
               ? PostUser?.profilePicture.toString()
               : (PostUser && nameToPicture(PostUser)) || ''
           }
-          name={`${props.User?.firstName} ${props.User?.lastName}`}
+          name={`${props.user?.firstName} ${props.user?.lastName}`}
           subtitle={formatDistanceToNow(
             new Date(props.createdAt || Date.now()),
             {
@@ -68,7 +68,7 @@ const PostHeader: React.FC<PostHeaderProps> = (props) => {
         />
         <PrivacyNotice
           privacyType={props.privacyType}
-          canEdit={user.userId === props.User?.id}
+          canEdit={user.userId === props.user?.id}
           isEditing={props.updatePostMeta.isLoading}
           onEdit={async (newPrivacyType) => {
             try {

--- a/src/config/environnement.ts
+++ b/src/config/environnement.ts
@@ -15,7 +15,7 @@ const ENV = {
   local: {
     apiUrl:
       Platform.select({
-        ios: 'https://56b4-24-46-118-53.ngrok-free.app', // 'https://vwanu-api-dev.webvitals.org',
+        ios: 'https://919e756052a9.ngrok-free.app', // 'https://vwanu-api-dev.webvitals.org',
         android: 'http://10.0.2.2:3000/api/v1/', // Special case for Android emulator
       }) || 'http://localhost:3000/api/v1/',
     timeout: 10000,

--- a/src/screens/timeline/ImageGallery.screen.tsx
+++ b/src/screens/timeline/ImageGallery.screen.tsx
@@ -32,7 +32,7 @@ const ImageGallery: React.FC = () => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const route = useRoute<GalleryScreenRouteProp>()
-  const images = route.params?.Media || []
+  const images = route.params?.media || []
 
   const [activeIndex, setActiveIndex] = React.useState(
     //@ts-ignore

--- a/types.d.ts
+++ b/types.d.ts
@@ -49,12 +49,12 @@ type Notice = 'public' | 'private' | 'network'
 
 export interface PostProps {
   postText?: string
-  Media?: Medias[]
+  media?: Medias[]
   createdAt?: string
   amountOfKorems: number
   amountOfComments: number
   likers?: User[]
-  User?: User
+  user?: User
   reactors: User[]
   id: number | string
   canDelete?: boolean


### PR DESCRIPTION
- Change Media to media in PostProps interface
- Change User to user in PostProps interface
- Update all component references to use new property names
- Update ngrok URL for local development
- Remove debug console.log statements

This improves code consistency by using camelCase naming convention throughout the PostProps interface and related components.