### PR TITLE
Vwa 115: Add mention in post input

### DIFF
--- a/src/components/CreatePost/PostInputModal/index.tsx
+++ b/src/components/CreatePost/PostInputModal/index.tsx
@@ -8,7 +8,6 @@ import {
   View,
   Modal,
   TouchableOpacity,
-  StatusBar,
   Animated,
   ScrollView,
 } from 'react-native'
@@ -29,7 +28,6 @@ import extractMentionIds from 'utils/extractMentionIds'
 import { Notice } from '../../../../types'
 import { useFetchProfileQuery } from 'store/profiles'
 import { RootState } from 'store'
-import nameToPicture from 'lib/nameToPicture'
 import { useFormikContext } from 'formik'
 import routes from 'navigation/routes'
 import { useTheme } from 'hooks/useTheme'

--- a/src/components/CreatePost/PostInputModal/index.tsx
+++ b/src/components/CreatePost/PostInputModal/index.tsx
@@ -17,14 +17,15 @@ import { styles } from './style'
 import tw from 'lib/tailwind'
 import ProfAvatar from '../../ProfAvatar'
 import {
-  Field,
   Form,
   Submit,
   ImageFields,
   PrivacyNoticeField,
+  MentionInput,
 } from '../../form'
 import Text from '../../Text'
 import { useCreatePostMutation } from 'store/post'
+import extractMentionIds from 'utils/extractMentionIds'
 import { Notice } from '../../../../types'
 import { useFetchProfileQuery } from 'store/profiles'
 import { RootState } from 'store'
@@ -179,8 +180,9 @@ const PostInputModal: React.FC<PostInputModalInterface> = ({
           validationSchema={ValidationSchema}
           initialValues={initialValues}
           onSubmit={async (values) => {
+            const mentions = extractMentionIds(values.postText || '')
             //@ts-ignore
-            await createPost(values)
+            await createPost({ ...values, mentions })
           }}
           style={tw`flex-1`}
         >
@@ -251,16 +253,16 @@ const PostInputModal: React.FC<PostInputModalInterface> = ({
 
             {/* Enhanced Text Input */}
             <View style={styles.textInputSection}>
-              <CustomField
-                //  ref={textInputRef}
+              <MentionInput
                 name="postText"
                 placeholder="What's on your mind?"
                 autoCapitalize="sentences"
                 style={styles.textInput}
                 multiline={true}
-                onChangeText={setPostText}
                 textAlignVertical="top"
               />
+
+              <PostTextSync onTextChange={setPostText} />
 
               {/* Character counter */}
               <View style={styles.characterCounter}>
@@ -376,17 +378,14 @@ const PostInputModal: React.FC<PostInputModalInterface> = ({
     </Modal>
   )
 }
-const CustomField = ({ onChangeText, ...props }: any) => {
-  const { setFieldValue } = useFormikContext()
-  return (
-    <Field
-      {...props}
-      onChangeText={(e) => {
-        setFieldValue(props.name, e)
-        onChangeText(e)
-      }}
-    />
-  )
+const PostTextSync: React.FC<{ onTextChange: (text: string) => void }> = ({
+  onTextChange,
+}) => {
+  const { values } = useFormikContext<any>()
+  React.useEffect(() => {
+    onTextChange(values.postText || '')
+  }, [values.postText])
+  return null
 }
 
 export default PostInputModal

--- a/src/components/LongText.tsx
+++ b/src/components/LongText.tsx
@@ -7,8 +7,11 @@ import {
   StyleProp,
 } from 'react-native'
 import Text from './Text'
+import MentionText from './MentionText'
 import tw from '../lib/tailwind'
 import useToggle from '../hooks/useToggle'
+import routes from '../navigation/routes'
+import { useNavigation } from '@react-navigation/native'
 
 interface LongTextProps extends TextProps {
   text: string
@@ -28,11 +31,22 @@ const LongText: React.FC<LongTextProps> = ({
   showShowMoreText = true,
   ...textProps
 }) => {
+  const navigation = useNavigation()
   const [isExpanded, toggleExpanded] = useToggle(false)
   const shouldTruncate = text.length > maxLength
 
   const displayText =
     shouldTruncate && !isExpanded ? `${text.slice(0, maxLength)}...` : text
+
+  const handleMentionPress = (id: string) => {
+    const parentNavigation = navigation.getParent()
+    const nav = parentNavigation || navigation
+    // @ts-ignore
+    nav.navigate(routes.ACCOUNT, {
+      screen: routes.PROFILE,
+      params: { profileId: id },
+    })
+  }
 
   const toggleButton = shouldTruncate && showShowMoreText && (
     <TouchableOpacity onPress={toggleExpanded}>
@@ -44,9 +58,9 @@ const LongText: React.FC<LongTextProps> = ({
 
   return (
     <View style={tw`flex flex-row flex-wrap items-center`}>
-      <Text style={textStyles} {...textProps}>
+      <MentionText style={textStyles} onMentionPress={handleMentionPress}>
         {displayText}
-      </Text>
+      </MentionText>
       {toggleButton}
     </View>
   )

--- a/src/store/post.ts
+++ b/src/store/post.ts
@@ -15,8 +15,11 @@ interface Rep {
   skip: number
 }
 
-type PostCreationProps = PostProps & { postImage: string[] }
-type CommentType = Partial<PostProps> & { postId: number }
+type PostCreationProps = PostProps & {
+  postImage: string[]
+  mentions?: string[]
+}
+type CommentType = Partial<PostProps> & { postId: number; mentions?: string[] }
 
 const _toFormData = (values: Partial<PostCreationProps>): FormData => {
   const formData = new FormData()
@@ -24,6 +27,11 @@ const _toFormData = (values: Partial<PostCreationProps>): FormData => {
   formData.append('privacyType', values?.privacyType || 'public')
   if (values?.communityId) {
     formData.append('communityId', values?.communityId || '')
+  }
+  if (values?.mentions?.length) {
+    values.mentions.forEach((id) => {
+      formData.append('mentions[]', id)
+    })
   }
   if (values?.postImage?.length) {
     values.postImage.forEach((uri) => {


### PR DESCRIPTION
This pull request enhances the post creation and display workflow by introducing support for user mentions in post text. Mentions are now extracted, passed through the post creation API, and rendered interactively in post displays. The most important changes are grouped below:

**Mention Extraction and Post Creation:**

* Added extraction of mention IDs from the post text using `extractMentionIds`, and included these IDs in the payload sent to the backend when creating a post (`src/components/CreatePost/PostInputModal/index.tsx`). [[1]](diffhunk://#diff-432694ef1aa20c135522914b7d1166baf0deed14e96dea55c2467223fd95cc0aL20-R28) [[2]](diffhunk://#diff-432694ef1aa20c135522914b7d1166baf0deed14e96dea55c2467223fd95cc0aR183-R185)
* Updated the post creation types and form data logic to support an optional `mentions` array, ensuring mention IDs are sent as part of the form data (`src/store/post.ts`). [[1]](diffhunk://#diff-5534d21459c8ac2acad36924c84940fc49f3fc6edd7d94fb37f2c4d88c545103L18-R22) [[2]](diffhunk://#diff-5534d21459c8ac2acad36924c84940fc49f3fc6edd7d94fb37f2c4d88c545103R31-R35)

**Input and Form Refactoring:**

* Replaced the custom text input field with a `MentionInput` component for enhanced mention handling, and introduced a `PostTextSync` helper to keep local state in sync with form values (`src/components/CreatePost/PostInputModal/index.tsx`). [[1]](diffhunk://#diff-432694ef1aa20c135522914b7d1166baf0deed14e96dea55c2467223fd95cc0aL254-R266) [[2]](diffhunk://#diff-432694ef1aa20c135522914b7d1166baf0deed14e96dea55c2467223fd95cc0aL379-R388)

**Mention Rendering and Navigation:**

* Updated the `LongText` component to use a new `MentionText` component, which renders mentions in the text as interactive elements. When a mention is pressed, the user is navigated to the mentioned profile (`src/components/LongText.tsx`). [[1]](diffhunk://#diff-f7cb4dc10a61454cebb1ea0020d21f7e8f7eb39d6004051a62167e0ace940374R10-R14) [[2]](diffhunk://#diff-f7cb4dc10a61454cebb1ea0020d21f7e8f7eb39d6004051a62167e0ace940374R34-R50) [[3]](diffhunk://#diff-f7cb4dc10a61454cebb1ea0020d21f7e8f7eb39d6004051a62167e0ace940374L47-R63)