### PR TITLE
VWA 98: Create community redesign

### DIFF
--- a/src/components/AppCloseBtn.tsx
+++ b/src/components/AppCloseBtn.tsx
@@ -11,7 +11,7 @@ const AppCloseBtn = ({ onPress }: AppCloseBtnProps) => {
   return (
     <Button
       onPress={onPress}
-      style={tw`px-4 py-2 rounded-full`}
+      style={tw`p-2 rounded-full border border-gray-300`}
       textStyle={tw`text-black`}
       appearance="ghost"
       size="small"

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native'
 
 import tw from 'lib/tailwind'
 import Text from './Text'
+import MentionText from './MentionText'
 import ProfAvatar from './ProfAvatar'
 import { PostProps } from '../../types'
 import LikeForm from './LikeForm'
@@ -57,7 +58,12 @@ const Comment: React.FC<CommentProps> = ({ comment }) => {
         }}
       />
       <View style={tw`flex-1 flex-row justify-between ml-3`}>
-        <Text style={tw`items-center mt-2`}>{comment.postText}</Text>
+        <MentionText
+          style={tw`items-center mt-2`}
+          onMentionPress={(id) => handleProfileNavigation(id)}
+        >
+          {comment.postText || ''}
+        </MentionText>
         <LikeForm
           id={comment.id.toString()}
           isReactor={!!comment.isReactor}

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -10,14 +10,16 @@ import {
   Text,
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
 import { useFormikContext } from 'formik'
 
 import tw from 'lib/tailwind'
 import { Notice } from '../../types'
-import { Form, Field, Submit } from './form'
+import { Form, MentionInput, Submit } from './form'
 import { useCreateCommentMutation } from 'store/post'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { useTheme } from 'hooks/useTheme'
+import extractMentionIds from 'utils/extractMentionIds'
 
 const validationSchema = object().shape({
   postText: string().label('Comment'),
@@ -55,9 +57,6 @@ const CommentForm = forwardRef<CommentFormHandle, CommentFormProps>(
     const inputRef = useRef<TextInput>(null)
     const { isDarkMode } = useTheme()
 
-    const MAX_CHARACTERS = 500
-    const remainingChars = MAX_CHARACTERS - commentText.length
-
     React.useEffect(() => {
       const keyboardWillShow = (event: any) => {
         const keyboardHeight = event.endCoordinates.height
@@ -93,7 +92,8 @@ const CommentForm = forwardRef<CommentFormHandle, CommentFormProps>(
     }, [insets.bottom])
 
     const handleSubmit = async (values: any, { resetForm }: any) => {
-      if (commentText.trim().length === 0) return
+      const postText = values.postText || ''
+      if (postText.trim().length === 0) return
 
       setIsSubmitting(true)
 
@@ -112,7 +112,8 @@ const CommentForm = forwardRef<CommentFormHandle, CommentFormProps>(
       ]).start()
 
       try {
-        await createComment({ ...values, postText: commentText })
+        const mentions = extractMentionIds(postText)
+        await createComment({ ...values, postText, mentions })
         onSubmit?.()
         resetForm()
         setCommentText('')
@@ -162,119 +163,124 @@ const CommentForm = forwardRef<CommentFormHandle, CommentFormProps>(
           onSubmit={handleSubmit}
           style={styles.formContainer}
         >
-          <View style={[styles.inputContainer]}>
-            <View
-              style={[
-                styles.inputWrapper,
-                {
-                  backgroundColor: isDarkMode
-                    ? tw.color('bg-gray-300')
-                    : tw.color('bg-white'),
-                },
-              ]}
-            >
-              <CustomField
-                ref={inputRef}
-                multiline
-                name="postText"
-                onChangeText={handleTextChange}
-                onContentSizeChange={handleContentSizeChange}
-                style={[styles.textInput, { height: inputHeight }]}
-                placeholder="Write a comment..."
-                placeholderTextColor="#9CA3AF"
-                maxLength={MAX_CHARACTERS}
-                textAlignVertical="top"
-                isDarkMode={isDarkMode}
-              />
-
-              {/* Character counter */}
-              <View style={styles.characterCounter}>
-                <Text
-                  style={[
-                    styles.counterText,
-                    remainingChars < 50 && styles.counterWarning,
-                    remainingChars === 0 && styles.counterError,
-                  ]}
-                >
-                  {remainingChars}
-                </Text>
-              </View>
-            </View>
-
-            {/* Send button */}
-            <Animated.View style={{ transform: [{ scale: sendButtonScale }] }}>
-              <Submit
-                appearance="ghost"
-                disabled={commentText.trim().length === 0 || isSubmitting}
-                accessoryRight={() =>
-                  isSubmitting ? (
-                    <MaterialCommunityIcons
-                      name="loading"
-                      size={18}
-                      color={
-                        commentText.trim().length > 0
-                          ? tw.color('bg-primary')
-                          : '#D1D5DB'
-                      }
-                    />
-                  ) : (
-                    <MaterialCommunityIcons
-                      name="send"
-                      size={18}
-                      color={
-                        commentText.trim().length > 0
-                          ? tw.color('bg-primary')
-                          : '#D1D5DB'
-                      }
-                    />
-                  )
-                }
-                size="small"
-                style={[
-                  styles.sendButton,
-                  commentText.trim().length > 0 && styles.sendButtonActive,
-                ]}
-              />
-            </Animated.View>
-          </View>
+          <CommentFormContent
+            commentText={commentText}
+            setCommentText={setCommentText}
+            inputHeight={inputHeight}
+            handleContentSizeChange={handleContentSizeChange}
+            isSubmitting={isSubmitting}
+            sendButtonScale={sendButtonScale}
+            isDarkMode={isDarkMode}
+          />
         </Form>
       </Animated.View>
     )
   }
 )
 
-interface CustomFieldProps {
-  name: string
-  onChangeText: (text: string) => void
-  onContentSizeChange: (event: any) => void
-  style: any
-  placeholder: string
-  placeholderTextColor: string
-  maxLength: number
-  textAlignVertical: 'auto' | 'center' | 'bottom' | 'top'
-  multiline: boolean
+const MAX_CHARACTERS = 500
+
+const CommentFormContent: React.FC<{
+  commentText: string
+  setCommentText: (text: string) => void
+  inputHeight: number
+  handleContentSizeChange: (event: any) => void
+  isSubmitting: boolean
+  sendButtonScale: Animated.Value
   isDarkMode: boolean
+}> = ({
+  commentText,
+  setCommentText,
+  inputHeight,
+  handleContentSizeChange,
+  isSubmitting,
+  sendButtonScale,
+  isDarkMode,
+}) => {
+  const { values } = useFormikContext<any>()
+  const postText = values.postText || ''
+
+  React.useEffect(() => {
+    setCommentText(postText)
+  }, [postText])
+
+  const remainingChars = MAX_CHARACTERS - commentText.length
+
+  return (
+    <View style={[styles.inputContainer]}>
+      <View
+        style={[
+          styles.inputWrapper,
+          {
+            backgroundColor: isDarkMode
+              ? tw.color('bg-gray-300')
+              : tw.color('bg-white'),
+          },
+        ]}
+      >
+        <MentionInput
+          multiline
+          name="postText"
+          onContentSizeChange={handleContentSizeChange}
+          style={[styles.textInput, { height: inputHeight }]}
+          placeholder="Write a comment..."
+          placeholderTextColor="#9CA3AF"
+          maxLength={MAX_CHARACTERS}
+          textAlignVertical="top"
+        />
+
+        {/* Character counter */}
+        <View style={styles.characterCounter}>
+          <Text
+            style={[
+              styles.counterText,
+              remainingChars < 50 && styles.counterWarning,
+              remainingChars === 0 && styles.counterError,
+            ]}
+          >
+            {remainingChars}
+          </Text>
+        </View>
+      </View>
+
+      {/* Send button */}
+      <Animated.View style={{ transform: [{ scale: sendButtonScale }] }}>
+        <Submit
+          appearance="ghost"
+          disabled={commentText.trim().length === 0 || isSubmitting}
+          accessoryRight={() =>
+            isSubmitting ? (
+              <MaterialCommunityIcons
+                name="loading"
+                size={18}
+                color={
+                  commentText.trim().length > 0
+                    ? tw.color('bg-primary')
+                    : '#D1D5DB'
+                }
+              />
+            ) : (
+              <MaterialCommunityIcons
+                name="send"
+                size={18}
+                color={
+                  commentText.trim().length > 0
+                    ? tw.color('bg-primary')
+                    : '#D1D5DB'
+                }
+              />
+            )
+          }
+          size="small"
+          style={[
+            styles.sendButton,
+            commentText.trim().length > 0 && styles.sendButtonActive,
+          ]}
+        />
+      </Animated.View>
+    </View>
+  )
 }
-
-const CustomField = forwardRef<TextInput, CustomFieldProps>(
-  ({ onChangeText, name, isDarkMode, ...props }, ref) => {
-    const { setFieldValue } = useFormikContext<any>()
-
-    return (
-      <Field
-        name={name}
-        {...props}
-        onChangeText={(text: string) => {
-          setFieldValue(name, text)
-          onChangeText(text)
-        }}
-        style={tw`flex-1 rounded-lg border-transparent ${
-          isDarkMode ? 'bg-gray-300' : 'bg-transparent'
-        }`}
-      />
-    )
-  }
-)
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/MentionText.tsx
+++ b/src/components/MentionText.tsx
@@ -10,6 +10,7 @@ interface MentionTextProps {
   style?: StyleProp<TextStyle>
   mentionStyle?: StyleProp<TextStyle>
   onMentionPress?: (id: string, name: string) => void
+  numberOfLines?: number
 }
 
 const MentionText: React.FC<MentionTextProps> = ({
@@ -17,6 +18,7 @@ const MentionText: React.FC<MentionTextProps> = ({
   style,
   mentionStyle,
   onMentionPress,
+  numberOfLines,
 }) => {
   const { parts } = useMemo(
     () => parseValue(children, mentionConfigs),
@@ -24,7 +26,7 @@ const MentionText: React.FC<MentionTextProps> = ({
   )
 
   return (
-    <Text style={style}>
+    <Text style={style} numberOfLines={numberOfLines}>
       {parts.map((part, index) =>
         part.data ? (
           <Text

--- a/src/components/form/FormHeader.tsx
+++ b/src/components/form/FormHeader.tsx
@@ -24,12 +24,12 @@ const FormHeader = ({
   const idleText = submitTitle || 'Create'
   return (
     <View
-      style={tw`flex-row items-center justify-between px-4 py-3 bg-white border-b border-gray-100`}
+      style={tw`flex-row items-center justify-between px-4 py-3 bg-white border-b border-t border-gray-200`}
     >
       <AppCloseBtn onPress={() => onClose()} />
 
       {title && (
-        <Text category="h6" style={tw`font-semibold text-lg `}>
+        <Text category="h6" style={tw`font-poppins-bold text-lg`}>
           {title}
         </Text>
       )}
@@ -38,7 +38,9 @@ const FormHeader = ({
         title={isLoading ? sumitting : idleText}
         size="small"
         disabled={isLoading}
-        style={tw`px-4 py-2 rounded-full`}
+        style={tw`px-4 py-2 rounded-full border border-gray-300 bg-[${
+          isLoading ? '#E5E7EB' : '#F5F3EE'
+        }]`}
       />
     </View>
   )

--- a/src/components/form/ImageUploadSection.tsx
+++ b/src/components/form/ImageUploadSection.tsx
@@ -108,54 +108,50 @@ const ImageUploadSection: React.FC<Props> = ({
   }
 
   return (
-    <View style={tw`bg-white px-4 py-6 border-b border-gray-100`}>
-      <Text category="h6" style={tw`font-semibold text-lg mb-4`}>
-        {label}
-      </Text>
-
+    <View>
       <TouchableOpacity
-        style={tw`w-full h-48 rounded-2xl overflow-hidden border-2 border-dashed border-gray-300`}
+        style={tw`w-full h-48 rounded-2xl border-2 border-dashed border-gray-300`}
         onPress={showImageOptions}
       >
-        {imageUri ? (
-          <ImageBackground
-            source={{ uri: imageUri }}
-            style={tw`w-full h-full`}
-            resizeMode="cover"
-          >
-            <View
-              style={tw`bg-black bg-opacity-30 w-full h-full flex justify-center items-center`}
+        <View style={tw`flex-1 rounded-2xl overflow-hidden`}>
+          {imageUri ? (
+            <ImageBackground
+              source={{ uri: imageUri }}
+              style={tw`w-full h-full`}
+              resizeMode="cover"
             >
-              <TouchableOpacity
-                style={tw`bg-white bg-opacity-90 w-12 h-12 rounded-full items-center justify-center`}
-                onPress={showImageOptions}
-              >
-                <Ionicons name="camera" size={24} color="#000" />
-              </TouchableOpacity>
-            </View>
-          </ImageBackground>
-        ) : (
-          <View
-            style={tw`w-full h-full bg-gray-50 flex justify-center items-center`}
-          >
-            <View style={tw`items-center`}>
               <View
-                style={tw`w-16 h-16 bg-gray-200 rounded-full items-center justify-center mb-3`}
+                style={tw`bg-black bg-opacity-30 w-full h-full flex justify-center items-center`}
               >
-                <Ionicons name="camera-outline" size={32} color="#6B7280" />
+                <TouchableOpacity
+                  style={tw`bg-white bg-opacity-90 w-12 h-12 rounded-full items-center justify-center`}
+                  onPress={showImageOptions}
+                >
+                  <Ionicons name="camera" size={24} color="#000" />
+                </TouchableOpacity>
               </View>
-              <Text style={tw`text-gray-600 font-medium text-base mb-1`}>
-                Add {label}
-              </Text>
-              <Text style={tw`text-gray-500 text-sm text-center`}>
-                {helperText || `Tap to upload a cover image`}
-              </Text>
+            </ImageBackground>
+          ) : (
+            <View
+              style={tw`w-full h-full bg-gray-50 flex justify-center items-center`}
+            >
+              <View style={tw`items-center`}>
+                <View
+                  style={tw`w-16 h-16 bg-gray-200 rounded-full items-center justify-center mb-3`}
+                >
+                  <Ionicons name="image-outline" size={32} color="#6B7280" />
+                </View>
+                <Text style={tw`font-poppins-bold mb-1`}>Add {label}</Text>
+                <Text style={tw`text-gray-500 text-sm text-center`}>
+                  {helperText || `Tap to upload a cover image`}
+                </Text>
+              </View>
             </View>
-          </View>
-        )}
+          )}
+        </View>
       </TouchableOpacity>
 
-      <Text style={tw`text-gray-500 text-xs mt-2`}>
+      <Text category="c1" appearance="hint" style={tw`text-center mt-2`}>
         Recommended size: 1200x675px (16:9 ratio)
       </Text>
     </View>

--- a/src/screens/Communities/CreateCommunity.tsx
+++ b/src/screens/Communities/CreateCommunity.tsx
@@ -167,18 +167,23 @@ const CreateCommunity = () => {
             isLoading={isLoading}
             submitTitle={isEditMode ? 'Update' : 'Create'}
             submittingText={isEditMode ? 'Updating...' : 'Creating...'}
+            title="Creating community"
           />
 
           <FormContent>
+            <Text category="h6" style={tw`font-poppins-bold text-lg mb-2 mt-4`}>
+              Community Image
+            </Text>
             <ImageUploadSection name="profilePicture" />
 
-            <Text category="h6" style={tw`font-semibold text-lg mb-4`}>
+            <Text category="h6" style={tw`font-poppins-bold text-lg mb-3 mt-4`}>
               Basic Information
             </Text>
             <Field
               name="name"
               placeholder="Enter community name"
-              style={tw`bg-gray-50`}
+              style={tw`bg-gray-50 rounded-lg mb-3`}
+              textStyle={tw`font-poppins`}
               required
               label="Community Name"
             />
@@ -186,13 +191,14 @@ const CreateCommunity = () => {
             <Field
               name="description"
               placeholder="Describe your community..."
-              style={tw`bg-gray-50 text-base min-h-20`}
+              style={tw`bg-gray-50 text-base rounded-lg`}
+              textStyle={tw`min-h-32 font-poppins`}
               required
               multiline
-              numberOfLines={4}
+              numberOfLines={6}
               label="Description"
             />
-            <PrivacySettings />
+            <View style={tw`mt-4`} />
             <InterestSelector
               name="interests"
               Label="Interests"
@@ -200,6 +206,7 @@ const CreateCommunity = () => {
               maxSelected={5}
               required={true}
             />
+            <PrivacySettings />
 
             {/* Bottom spacing */}
             <View style={tw`h-20`} />

--- a/src/screens/Communities/CreateCommunity.tsx
+++ b/src/screens/Communities/CreateCommunity.tsx
@@ -22,6 +22,7 @@ import { InferType } from 'yup'
 import { isEqual } from 'lodash'
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { SerializedError } from '@reduxjs/toolkit'
+import PrivacySettings from './components/PrivacySettings'
 
 type NavigationProp = StackNavigationProp<
   CommunityStackParams,
@@ -154,7 +155,7 @@ const CreateCommunity = () => {
   }
   return (
     <Screen loading={isLoading} error={unifiedError as any}>
-      <View style={tw`flex-1 bg-gray-50 px-3`}>
+      <View style={tw`flex-1  px-3`}>
         <Form
           validationSchema={ValidationSchema}
           initialValues={initialValues}
@@ -191,7 +192,7 @@ const CreateCommunity = () => {
               numberOfLines={4}
               label="Description"
             />
-
+            <PrivacySettings />
             <InterestSelector
               name="interests"
               Label="Interests"
@@ -199,13 +200,6 @@ const CreateCommunity = () => {
               maxSelected={5}
               required={true}
             />
-
-            {/* <PrivacySettings
-            privacyType={(values['privacyType'] || 'public') as CommunityPrivacyType}
-            requireApproval={values['requireApproval'] || false}
-            onPrivacyTypeChange={(privacyType) => setFieldValue('privacyType', privacyType)}
-            onApprovalChange={(requireApproval) => setFieldValue('requireApproval', requireApproval)}
-          /> */}
 
             {/* Bottom spacing */}
             <View style={tw`h-20`} />

--- a/src/screens/Communities/components/PrivacySettings.tsx
+++ b/src/screens/Communities/components/PrivacySettings.tsx
@@ -68,10 +68,10 @@ const PrivacySettings: React.FC<Props> = ({ name = 'privacyType' }) => {
             color={isSelected ? PRIMARY_3 : SOFT}
           />
         </View>
-        <Text style={tw`font-bold text-[13.5px] text-[#1A1A2E] mb-0.5`}>
+        <Text style={tw`font-poppins-bold text-[13.5px] text-[#1A1A2E] mb-0.5`}>
           {option.title}
         </Text>
-        <Text style={tw`text-[11.5px] text-[#8A8A9E] leading-4`}>
+        <Text style={tw`font-poppins text-[11.5px] text-[#8A8A9E] leading-4`}>
           {option.description}
         </Text>
       </TouchableOpacity>
@@ -79,9 +79,11 @@ const PrivacySettings: React.FC<Props> = ({ name = 'privacyType' }) => {
   }
 
   return (
-    <View style={tw` px-4 py-6 border-b border-gray-100`}>
-      <View style={tw`mb-6`}>
-        <Text style={tw`font-medium text-base mb-3`}>Visibility</Text>
+    <View style={tw`my-2 border-b border-gray-100`}>
+      <View style={tw``}>
+        <Text category="h6" style={tw`font-poppins-bold text-lg mb-4`}>
+          Visibility
+        </Text>
         <View style={tw`flex-row gap-2.5`}>
           {privacyOptions.map(renderPrivacyOption)}
         </View>

--- a/src/screens/Communities/components/PrivacySettings.tsx
+++ b/src/screens/Communities/components/PrivacySettings.tsx
@@ -1,68 +1,46 @@
 import React from 'react'
 import { View, TouchableOpacity } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
+import { useFormikContext } from 'formik'
 
 import Text from 'components/Text'
 import tw from 'lib/tailwind'
 import { CommunityPrivacyType } from '../../../../types'
 
 interface Props {
-  privacyType: CommunityPrivacyType
-  requireApproval: boolean
-  onPrivacyTypeChange: (type: CommunityPrivacyType) => void
-  onApprovalChange: (requireApproval: boolean) => void
+  name?: string
 }
 
-const PrivacySettings: React.FC<Props> = ({
-  privacyType,
-  requireApproval,
-  onPrivacyTypeChange,
-  onApprovalChange,
-}) => {
+const PRIMARY = '#1B1F5E'
+const PRIMARY_3 = '#4A5295'
+const SOFT = '#4A4A5E'
+
+const PrivacySettings: React.FC<Props> = ({ name = 'privacyType' }) => {
+  const { values, setFieldValue } = useFormikContext<any>()
+  const privacyType = (values[name] || 'public') as CommunityPrivacyType
+  const onPrivacyTypeChange = (type: CommunityPrivacyType) =>
+    setFieldValue(name, type)
+
   const privacyOptions = [
     {
       type: 'public' as CommunityPrivacyType,
       icon: 'globe-outline' as const,
       title: 'Public',
-      description: 'Anyone can see and join this community',
-      infoText:
-        'Your community will be discoverable by all users and appear in search results.',
+      description: 'Anyone can find and join',
     },
     {
       type: 'private' as CommunityPrivacyType,
       icon: 'people-outline' as const,
       title: 'Private',
-      description:
-        'Only members can see content, but the community is searchable',
-      infoText:
-        'Your community will appear in search but only members can see posts and content.',
+      description: 'Members-only, searchable',
     },
     {
       type: 'hidden' as CommunityPrivacyType,
       icon: 'lock-closed-outline' as const,
       title: 'Hidden',
-      description: 'Completely hidden from search, invite-only access',
-      infoText:
-        'Your community will be completely hidden from search and only accessible by invitation.',
+      description: 'Invite-only, hidden',
     },
   ]
-
-  const renderToggle = (value: boolean, onToggle: (value: boolean) => void) => (
-    <TouchableOpacity
-      style={[
-        tw`w-12 h-6 rounded-full flex-row items-center px-1`,
-        value ? tw`bg-blue-500` : tw`bg-gray-300`,
-      ]}
-      onPress={() => onToggle(!value)}
-    >
-      <View
-        style={[
-          tw`w-4 h-4 rounded-full bg-white`,
-          value ? tw`ml-auto` : tw`ml-0`,
-        ]}
-      />
-    </TouchableOpacity>
-  )
 
   const renderPrivacyOption = (option: (typeof privacyOptions)[0]) => {
     const isSelected = privacyType === option.type
@@ -71,116 +49,41 @@ const PrivacySettings: React.FC<Props> = ({
       <TouchableOpacity
         key={option.type}
         style={[
-          tw`flex-row items-start p-4 rounded-xl border-2 mb-3`,
+          tw`flex-1 p-3 rounded-2xl border`,
           isSelected
-            ? tw`border-blue-500 bg-blue-50`
-            : tw`border-gray-200 bg-white`,
+            ? tw`border-[${PRIMARY}] bg-[#EEF0FA]`
+            : tw`border-[#D4D1C8] bg-[#F5F3EE]`,
         ]}
         onPress={() => onPrivacyTypeChange(option.type)}
       >
-        <View style={tw`mr-3 mt-1`}>
+        <View
+          style={[
+            tw`w-8 h-8 rounded-full items-center justify-center mb-2`,
+            isSelected ? tw`bg-[#EEF0FA]` : tw`bg-[#E4E2DC]`,
+          ]}
+        >
           <Ionicons
             name={option.icon}
-            size={24}
-            color={isSelected ? '#3B82F6' : '#6B7280'}
+            size={16}
+            color={isSelected ? PRIMARY_3 : SOFT}
           />
         </View>
-        <View style={tw`flex-1`}>
-          <Text
-            style={[
-              tw`font-semibold text-base mb-1`,
-              isSelected ? tw`text-blue-800` : tw`text-gray-800`,
-            ]}
-          >
-            {option.title}
-          </Text>
-          <Text
-            style={[
-              tw`text-sm leading-5`,
-              isSelected ? tw`text-blue-700` : tw`text-gray-600`,
-            ]}
-          >
-            {option.description}
-          </Text>
-        </View>
-        <View style={tw`ml-3 mt-1`}>
-          <View
-            style={[
-              tw`w-5 h-5 rounded-full border-2 items-center justify-center`,
-              isSelected
-                ? tw`border-blue-500 bg-blue-500`
-                : tw`border-gray-300`,
-            ]}
-          >
-            {isSelected && (
-              <Ionicons name="checkmark" size={12} color="white" />
-            )}
-          </View>
-        </View>
+        <Text style={tw`font-bold text-[13.5px] text-[#1A1A2E] mb-0.5`}>
+          {option.title}
+        </Text>
+        <Text style={tw`text-[11.5px] text-[#8A8A9E] leading-4`}>
+          {option.description}
+        </Text>
       </TouchableOpacity>
     )
   }
 
-  const selectedOption = privacyOptions.find(
-    (option) => option.type === privacyType
-  )
-
   return (
-    <View style={tw`bg-white px-4 py-6 border-b border-gray-100`}>
-      <Text category="h6" style={tw`font-semibold text-lg mb-4`}>
-        Privacy & Access
-      </Text>
-
-      {/* Privacy Type Selection */}
+    <View style={tw` px-4 py-6 border-b border-gray-100`}>
       <View style={tw`mb-6`}>
-        <Text style={tw`text-gray-700 font-medium text-base mb-3`}>
-          Who can see this community?
-        </Text>
-        {privacyOptions.map(renderPrivacyOption)}
-      </View>
-
-      {/* Member Approval Setting - Only show for public and private communities */}
-      {privacyType !== 'hidden' && (
-        <View style={tw`flex-row justify-between items-start mb-6`}>
-          <View style={tw`flex-1 mr-4`}>
-            <View style={tw`flex-row items-center mb-2`}>
-              <Ionicons
-                name="checkmark-circle-outline"
-                size={20}
-                color="#6B7280"
-                style={tw`mr-2`}
-              />
-              <Text style={tw`text-gray-800 font-medium text-base`}>
-                Require Approval
-              </Text>
-            </View>
-            <Text style={tw`text-gray-600 text-sm leading-5`}>
-              {privacyType === 'private'
-                ? 'Review join requests before accepting new members'
-                : 'Moderators must approve new members before they can join'}
-            </Text>
-          </View>
-          {renderToggle(requireApproval, onApprovalChange)}
-        </View>
-      )}
-
-      {/* Info box */}
-      <View style={tw`bg-blue-50 p-4 rounded-xl`}>
-        <View style={tw`flex-row items-start`}>
-          <Ionicons
-            name="information-circle"
-            size={20}
-            color="#3B82F6"
-            style={tw`mr-2 mt-0.5`}
-          />
-          <View style={tw`flex-1`}>
-            <Text style={tw`text-blue-800 font-medium text-sm mb-1`}>
-              Privacy Settings
-            </Text>
-            <Text style={tw`text-blue-700 text-xs leading-4`}>
-              {selectedOption?.infoText}
-            </Text>
-          </View>
+        <Text style={tw`font-medium text-base mb-3`}>Visibility</Text>
+        <View style={tw`flex-row gap-2.5`}>
+          {privacyOptions.map(renderPrivacyOption)}
         </View>
       </View>
     </View>

--- a/types.d.ts
+++ b/types.d.ts
@@ -395,6 +395,7 @@ export interface CreateDiscussionParams {
   interestId: string
   title: string
   body: string
+  mentions?: string[]
 }
 
 export interface CreateDiscussionReplyParams {


### PR DESCRIPTION
TITLE:
style(create-community): redesign screen to match new design (VWA-98)

BODY:
## Summary
- Redesign the Create Community screen to match the new reference design
- Convert privacy options from stacked rows to three horizontal cards and move them below Interests
- Apply Poppins across section titles, form fields, and privacy cards; round field corners; enlarge the Description textarea
- Restyle the form header and close button; restructure the image upload so the dashed border renders on iOS

## Test plan
- [ ] Open Create Community — header renders with Poppins title, page shows cream bg, description field is visibly taller, image upload has a dashed border
- [ ] Tap Public / Private / Hidden cards — selection toggles correctly (blue bg + border)
- [ ] Pick an image — preview fills the rounded frame without clipping, dashed border stays visible
- [ ] Create and edit a community end-to-end — form validates and saves
