### PR TITLE
VWA 124: add presign mutation + direct-to-S3 upload helper (VWA…

### DIFF
--- a/src/lib/uploadToS3.ts
+++ b/src/lib/uploadToS3.ts
@@ -1,0 +1,90 @@
+export type UploadProgress = {
+  loaded: number
+  total: number
+  percent: number
+}
+
+export type UploadToS3Options = {
+  onProgress?: (progress: UploadProgress) => void
+  signal?: AbortSignal
+}
+
+const uriToBlob = async (fileUri: string): Promise<Blob> => {
+  const response = await fetch(fileUri)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read local file (${response.status}): ${fileUri}`
+    )
+  }
+  return response.blob()
+}
+
+export const uploadToS3 = async (
+  uploadUrl: string,
+  fileUri: string,
+  mimeType: string,
+  options: UploadToS3Options = {}
+): Promise<void> => {
+  const { onProgress, signal } = options
+
+  if (signal?.aborted) {
+    throw new DOMException('Upload aborted', 'AbortError')
+  }
+
+  const blob = await uriToBlob(fileUri)
+
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+
+    const onAbort = () => {
+      xhr.abort()
+    }
+
+    const cleanup = () => {
+      if (signal) signal.removeEventListener('abort', onAbort)
+    }
+
+    xhr.open('PUT', uploadUrl, true)
+    xhr.setRequestHeader('Content-Type', mimeType)
+
+    if (onProgress) {
+      xhr.upload.onprogress = (event) => {
+        if (!event.lengthComputable) return
+        const percent =
+          event.total > 0 ? Math.round((event.loaded / event.total) * 100) : 0
+        onProgress({ loaded: event.loaded, total: event.total, percent })
+      }
+    }
+
+    xhr.onload = () => {
+      cleanup()
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve()
+        return
+      }
+      reject(
+        new Error(
+          `S3 upload failed (${xhr.status}): ${
+            xhr.responseText || xhr.statusText
+          }`
+        )
+      )
+    }
+
+    xhr.onerror = () => {
+      cleanup()
+      reject(new Error('Network error during S3 upload'))
+    }
+
+    xhr.onabort = () => {
+      cleanup()
+      reject(new DOMException('Upload aborted', 'AbortError'))
+    }
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort)
+    }
+
+    xhr.send(blob)
+  })
+}

--- a/src/store/uploads-api-slice.ts
+++ b/src/store/uploads-api-slice.ts
@@ -1,0 +1,42 @@
+import apiSlice from './api-slice'
+import { HttpMethods } from '../config'
+
+export type UploadType = 'post' | 'profile' | 'message' | 'blog' | 'community'
+
+export interface PresignFileRequest {
+  filename: string
+  mimeType: string
+  uploadType: UploadType
+}
+
+export interface PresignFileResponse {
+  key: string
+  uploadUrl: string
+  publicUrl: string
+  expiresAt: string
+}
+
+export interface PresignBatchRequest {
+  files: PresignFileRequest[]
+}
+
+export interface PresignBatchResponse {
+  files: PresignFileResponse[]
+}
+
+export const uploadsApiSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getPresignedUploadUrls: builder.mutation<
+      PresignBatchResponse,
+      PresignBatchRequest
+    >({
+      query: (body) => ({
+        url: '/uploads/presign',
+        method: HttpMethods.POST,
+        body,
+      }),
+    }),
+  }),
+})
+
+export const { useGetPresignedUploadUrlsMutation } = uploadsApiSlice


### PR DESCRIPTION
…-124)

Introduces the building blocks for the new direct-to-S3 upload flow:

- uploads-api-slice: RTK Query mutation getPresignedUploadUrls hitting POST /uploads/presign. Auth headers (Authorization + x-id-token) come from the existing baseQueryWithReauth in api-slice.
- uploadToS3 lib: XHR-based PUT with progress events, AbortSignal cancellation, and clear error messages on non-2xx responses.

No UX change — VWA-125 wires these into the post composer.