### PR TITLE
Vwa-130: Add optional fileType to presign request

### DIFF
--- a/src/store/uploads-api-slice.ts
+++ b/src/store/uploads-api-slice.ts
@@ -3,10 +3,18 @@ import { HttpMethods } from '../config'
 
 export type UploadType = 'post' | 'profile' | 'message' | 'blog' | 'community'
 
+export type ProfileFileType = 'profilePicture' | 'coverPicture'
+
 export interface PresignFileRequest {
   filename: string
   mimeType: string
   uploadType: UploadType
+  /**
+   * Discriminator for `uploadType: 'profile'` to choose between
+   * profilePicture / coverPicture (drives the S3 key prefix on the
+   * backend via generateS3Key). Ignored for other upload types.
+   */
+  fileType?: ProfileFileType
 }
 
 export interface PresignFileResponse {


### PR DESCRIPTION
## Summary

Companion to backend [VWA-130](https://linear.app/vwanu/issue/VWA-130). Adds an optional `fileType` field to `PresignFileRequest` so callers can specify `profilePicture` vs `coverPicture` for `uploadType: 'profile'`. The backend uses this to pick the right S3 prefix via the existing `generateS3Key` helper.

Pure type addition — no runtime change for existing callers (all current code paths use `uploadType: 'post'` from VWA-125 and don't pass `fileType`).

## Backend coordination

This PR is a no-op until the backend (separate PR) ships. Once both land, surface tickets VWA-127 (profile picture migration) can pass `fileType` and uploads will land in `profiles/pictures/...` / `profiles/covers/...` instead of the wrong default.

Parent: [VWA-88](https://linear.app/vwanu/issue/VWA-88)