### PR TITLE
VWA-132:Add CloudFront image URL helper and wire avatars + feed images

### DIFF
--- a/src/components/ImageGrid.tsx
+++ b/src/components/ImageGrid.tsx
@@ -13,6 +13,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons'
 import tw from '../lib/tailwind'
 import { Media } from '../../types'
 import { splitImages } from '../lib/splitImages'
+import { cdnImageUrl } from '../lib/cdnImageUrl'
 
 /**
  * Props for the ImageGrid component.
@@ -86,7 +87,7 @@ const ImageGrid: React.FC<ImageGridProps> = (props) => {
           </>
         ) : (
           <Image
-            source={{ uri: item.original }}
+            source={{ uri: cdnImageUrl(item.original, 'medium') }}
             style={style}
             contentFit="cover"
             placeholder="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="

--- a/src/components/ProfAvatar.tsx
+++ b/src/components/ProfAvatar.tsx
@@ -71,6 +71,7 @@ const ProfAvatar: React.FC<ProfAvatarProps> = ({
             uri: cdnImageUrl(props.user.profilePicture, {
               width: size * 2, // 2x for retina
               height: size * 2,
+              smartCrop: true, // focus on face if Rekognition finds one
             }),
           }}
         />

--- a/src/components/ProfAvatar.tsx
+++ b/src/components/ProfAvatar.tsx
@@ -7,6 +7,7 @@ import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import LongText from './LongText'
 import routes from 'navigation/routes'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 interface ProfAvatarProps {
   user: User
@@ -64,7 +65,15 @@ const ProfAvatar: React.FC<ProfAvatarProps> = ({
       disabled={disableDefaultNavigation}
     >
       <View>
-        <Avatar.Image size={size} source={{ uri: props.user.profilePicture }} />
+        <Avatar.Image
+          size={size}
+          source={{
+            uri: cdnImageUrl(props.user.profilePicture, {
+              width: size * 2, // 2x for retina
+              height: size * 2,
+            }),
+          }}
+        />
         {showOnlineStatus && props.user.online !== undefined && (
           <View
             style={tw`absolute bottom-0 right-0 w-4 h-4 rounded-full border-2 border-white dark:border-gray-800 ${

--- a/src/lib/cdnImageUrl.ts
+++ b/src/lib/cdnImageUrl.ts
@@ -1,0 +1,120 @@
+/**
+ * Builds CloudFront URLs that hit the AWS Dynamic Image Transformation
+ * Lambda@Edge handler (deployed via VWA-131). The handler accepts requests
+ * shaped as `<cdn-host>/<base64(JSON)>` where the JSON describes an edit
+ * pipeline applied to the source S3 object.
+ *
+ * Two ways to call:
+ *   cdnImageUrl(key, 'medium')                       // preset
+ *   cdnImageUrl(key, { width: 400, height: 200 })    // explicit
+ *   cdnImageUrl(key, { preset: 'medium', width: 800 }) // preset + override
+ *
+ * Backwards compat: if a full S3 URL is passed instead of a key, the bucket
+ * prefix is stripped and the key extracted. External URLs (Cloudinary,
+ * Unsplash placeholders) are returned unchanged — only S3 URLs go through
+ * the CDN.
+ */
+
+const CDN_URL = process.env.EXPO_PUBLIC_CDN_URL
+const BUCKET = process.env.EXPO_PUBLIC_S3_BUCKET
+
+export type ImagePreset = 'thumb' | 'small' | 'medium' | 'large' | 'original'
+
+export type ImageFit = 'cover' | 'contain' | 'inside' | 'outside' | 'fill'
+
+export interface ImageOptions {
+  preset?: ImagePreset
+  width?: number
+  height?: number
+  fit?: ImageFit
+}
+
+const PRESETS: Record<ImagePreset, { width?: number; height?: number }> = {
+  thumb: { width: 100, height: 100 },
+  small: { width: 200, height: 200 },
+  medium: { width: 600 },
+  large: { width: 1200 },
+  original: {},
+}
+
+const isS3Url = (s: string): boolean => /\.amazonaws\.com\//.test(s)
+
+const extractKey = (url: string): string | null => {
+  const m = url.match(/\.amazonaws\.com\/(.+?)(\?.*)?$/)
+  return m ? m[1] : null
+}
+
+const base64Encode = (str: string): string => {
+  if (typeof btoa === 'function') return btoa(str)
+  // RN < 0.74 / Node test env fallback
+  // @ts-ignore — Buffer may not exist on all RN runtimes
+  return Buffer.from(str, 'utf-8').toString('base64')
+}
+
+const resolveSize = (
+  options: ImageOptions
+): { width?: number; height?: number; fit?: ImageFit } => {
+  const fromPreset = options.preset ? PRESETS[options.preset] : {}
+  const width = options.width ?? fromPreset.width
+  const height = options.height ?? fromPreset.height
+  if (width === undefined && height === undefined) return {}
+  // When BOTH are set, fit decides crop vs letterbox. Default to cover
+  // (fill the box, may crop) — matches what avatars/feed tiles want.
+  const fit =
+    options.fit ??
+    (width !== undefined && height !== undefined ? 'cover' : undefined)
+  return { width, height, fit }
+}
+
+const normaliseInput = (
+  options: ImageOptions | ImagePreset | undefined
+): ImageOptions => {
+  if (typeof options === 'string') return { preset: options }
+  return options ?? { preset: 'medium' }
+}
+
+export const cdnImageUrl = (
+  keyOrUrl: string | null | undefined,
+  options: ImageOptions | ImagePreset = 'medium'
+): string | undefined => {
+  if (!keyOrUrl) return undefined
+
+  // External URL (Cloudinary, Unsplash, etc.) — return as-is, don't proxy.
+  if (/^https?:\/\//.test(keyOrUrl) && !isS3Url(keyOrUrl)) return keyOrUrl
+
+  // S3 URL — extract the key for further processing.
+  let key = keyOrUrl
+  if (isS3Url(keyOrUrl)) {
+    const extracted = extractKey(keyOrUrl)
+    if (!extracted) return keyOrUrl
+    key = extracted
+  }
+
+  // CDN not configured — fall back to direct S3 URL (local dev safety net).
+  if (!CDN_URL || !BUCKET) {
+    if (keyOrUrl.startsWith('http')) return keyOrUrl
+    return BUCKET ? `https://${BUCKET}.s3.amazonaws.com/${key}` : undefined
+  }
+
+  const opts = normaliseInput(options)
+  const size = resolveSize(opts)
+
+  const request: {
+    bucket: string
+    key: string
+    edits?: Record<string, unknown>
+  } = {
+    bucket: BUCKET,
+    key,
+  }
+  if (size.width !== undefined || size.height !== undefined) {
+    const resize: Record<string, unknown> = {}
+    if (size.width !== undefined) resize.width = size.width
+    if (size.height !== undefined) resize.height = size.height
+    if (size.fit !== undefined) resize.fit = size.fit
+    request.edits = { resize }
+  }
+
+  const encoded = base64Encode(JSON.stringify(request))
+  return `${CDN_URL.replace(/\/$/, '')}/${encoded}`
+}

--- a/src/lib/cdnImageUrl.ts
+++ b/src/lib/cdnImageUrl.ts
@@ -22,11 +22,28 @@ export type ImagePreset = 'thumb' | 'small' | 'medium' | 'large' | 'original'
 
 export type ImageFit = 'cover' | 'contain' | 'inside' | 'outside' | 'fill'
 
+export interface SmartCropOptions {
+  /**
+   * 0-based index into faces detected by Rekognition, ordered largest →
+   * smallest. Default 0 = primary (largest) face.
+   */
+  faceIndex?: number
+  /** Padding in pixels around the cropped face. */
+  padding?: number
+}
+
 export interface ImageOptions {
   preset?: ImagePreset
   width?: number
   height?: number
   fit?: ImageFit
+  /**
+   * Focus the crop on a face detected via Amazon Rekognition. Costs a
+   * Rekognition.DetectFaces call per cache-miss (~$0.001/image). Pair
+   * with explicit width+height for square avatar-style crops.
+   * Not supported for animated GIFs — handler returns an error.
+   */
+  smartCrop?: boolean | SmartCropOptions
 }
 
 const PRESETS: Record<ImagePreset, { width?: number; height?: number }> = {
@@ -107,13 +124,18 @@ export const cdnImageUrl = (
     bucket: BUCKET,
     key,
   }
+  const edits: Record<string, unknown> = {}
   if (size.width !== undefined || size.height !== undefined) {
     const resize: Record<string, unknown> = {}
     if (size.width !== undefined) resize.width = size.width
     if (size.height !== undefined) resize.height = size.height
     if (size.fit !== undefined) resize.fit = size.fit
-    request.edits = { resize }
+    edits.resize = resize
   }
+  if (opts.smartCrop !== undefined && opts.smartCrop !== false) {
+    edits.smartCrop = opts.smartCrop
+  }
+  if (Object.keys(edits).length > 0) request.edits = edits
 
   const encoded = base64Encode(JSON.stringify(request))
   return `${CDN_URL.replace(/\/$/, '')}/${encoded}`


### PR DESCRIPTION
## Summary

Adds `cdnImageUrl()` — a single helper that builds CloudFront URLs hitting the AWS Dynamic Image Transformation Lambda@Edge handler deployed in [VWA-131](https://linear.app/vwanu/issue/VWA-131). Wires it into the two highest-traffic image surfaces (profile avatars + feed post images) as the proof. Other surfaces migrate alongside their per-surface tickets to avoid file-conflict hell.

[VWA-132](https://linear.app/vwanu/issue/VWA-132) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

## What's new

### `src/lib/cdnImageUrl.ts`

Two ways to call:

```ts
cdnImageUrl(key, 'medium')                          // preset
cdnImageUrl(key, { width: 400, height: 200 })       // explicit
cdnImageUrl(key, { preset: 'medium', width: 800 })  // preset + override
```

Builds `<CDN_URL>/<base64(JSON)>` per the AWS image handler convention. JSON shape:
```json
{ "bucket": "dev-vwanu-uploads", "key": "posts/.../foo.jpg", "edits": { "resize": { "width": 600, "fit": "cover" } } }
```

### Presets

| Preset | Width × Height | Use case |
|---|---|---|
| `thumb` | 100×100 | avatars, comment authors |
| `small` | 200×200 | feed cards, search results |
| `medium` | 600×_ | feed post images, blog cards |
| `large` | 1200×_ | full post view, blog detail |
| `original` | (no resize) | gallery, download |

Quality control deferred — `AutoWebP: Yes` on the Lambda@Edge handler gives most of the bandwidth win automatically when the client sends `Accept: image/webp` (`expo-image` does on iOS/Android).

### Backwards-compat behavior

- **Null/empty input** → returns `undefined` (component shows placeholder).
- **External URL** (Cloudinary, Unsplash placeholders) → returned unchanged. Don't proxy non-S3 sources.
- **Already an S3 URL** (e.g. legacy DB rows) → key extracted, then proxied.
- **CDN env unset** → returns the raw S3 URL as a safety net so the app doesn't break in environments that haven't been configured (local dev, untested testers).

## Components wired

- **`ProfAvatar`** — uses explicit `{ width: size * 2, height: size * 2 }` (2x for retina).
- **`ImageGrid`** — uses `'medium'` preset for feed post images. Videos still served direct from S3 (Lambda@Edge handler doesn't transform video).

## env wiring (you do this manually after deploy)

In `vwanu-mobile-application/.env.local`:

```
EXPO_PUBLIC_CDN_URL=https://<cloudfront-domain-from-VWA-131-deploy>
EXPO_PUBLIC_S3_BUCKET=dev-vwanu-uploads
```

The CloudFront domain is exposed as the CFN export `vwanu-api-backend-dev-ImageHandlerApiEndpoint`.

For real builds: set the same vars in EAS env config per stage.

## Test plan

- [ ] App builds with `EXPO_PUBLIC_CDN_URL` unset → all avatars/feed images still render (fallback to direct S3).
- [ ] Set both env vars → restart Expo → avatars and feed images now load from `<cdn>/<base64>`.
- [ ] First load slower (cache miss + transform), second load fast (CloudFront cache hit).
- [ ] Profile screen avatar uses `width: 100, height: 100` (50px display × 2x).
- [ ] Feed post images use `width: 600`.
- [ ] External avatar URLs (test users with Unsplash placeholders) still render directly.

## Out of scope

- Migrating DB to store key not URL → VWA-133.
- Sweeping every image-rendering component → handled in per-surface tickets (VWA-127/128/129) so we don't double-touch the same files.
- Signed URLs / CORS tightening → AWS solution deployed with `EnableSignature: No`; future hardening ticket.