### PR TITLE
VWA-136:Handle PROFILE_COMPLETE step in registration navigator

### DIFF
--- a/src/navigation/updateuser.navigator.tsx
+++ b/src/navigation/updateuser.navigator.tsx
@@ -68,6 +68,12 @@ const RegisterNavigator = () => {
       case NextCompletionStep.PROFILE_PICTURE:
         navigation.navigate(routes.PROFILE_PICTURE)
         break
+      case NextCompletionStep.PROFILE_COMPLETE:
+        // No-op — parent navigator (src/navigation/index.tsx) swaps this
+        // out for DrawerNavigator. Hitting `default` here would re-route
+        // back to PROFILE_PICTURE during the swap-out frame and the user
+        // would briefly see the picker again after registering.
+        break
       case NextCompletionStep.START:
       default:
         // navigation.navigate(routes.MORE_INFO)


### PR DESCRIPTION
## Symptom

After picking a profile picture and tapping Register on the registration flow, the user is bounced back to the same profile picture screen instead of advancing to the main app.

[VWA-136](https://linear.app/vwanu/issue/VWA-136)

## Root cause

`src/navigation/updateuser.navigator.tsx` has a `useEffect` switch on the user's `nextCompletionStep`. It handles values 1 (START), 2 (FIND_FRIENDS), and 3 (PROFILE_PICTURE) — but **no case for 4 (PROFILE_COMPLETE)**.

When submit succeeds, the user's `nextCompletionStep` becomes `4`. The parent navigator (`src/navigation/index.tsx`) correctly checks for `PROFILE_COMPLETE` and swaps to `DrawerNavigator`, but the inner navigator's `useEffect` fires first and falls into the `default` branch — which navigates back to `routes.PROFILE_PICTURE`. The user briefly sees the picker before the parent unmounts the registration navigator (or sees it persistently if the parent's check races differently).

## Fix

One-line — add a `case NextCompletionStep.PROFILE_COMPLETE: break` so the parent owns the transition:

```tsx
switch (nextAction) {
  case NextCompletionStep.FIND_FRIENDS:   navigation.navigate(routes.FIND_FRIEND); break
  case NextCompletionStep.PROFILE_PICTURE: navigation.navigate(routes.PROFILE_PICTURE); break
  case NextCompletionStep.PROFILE_COMPLETE: break   // ← NEW: parent renders DrawerNavigator
  case NextCompletionStep.START:
  default: navigation.navigate(routes.PROFILE_PICTURE); break
}
```

## Discovered during

Verifying VWA-127 (profile picture migration to presign flow). Pre-existing bug — not introduced by VWA-127. Hotfixed separately to keep VWA-127 focused on the migration itself.

## Test plan

- [ ] Sign up a new user → reach profile picture step → pick image → submit → verify lands on main app (Drawer).
- [ ] Use Skip button → verify also lands on main app.
- [ ] Existing users with `nextCompletionStep === 4` continue to see main app on app launch.