### PR TITLE
VWA-133:Drop Media variant type fields (FE)

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -29,11 +29,13 @@ interface ListItem {
 
 interface Media {
   id: number
+  /**
+   * S3 key (e.g. `posts/2026/05/03/<uuid>.jpg`) or external URL passthrough
+   * (Cloudinary/UI-Avatars/etc.). Build the rendered URL via cdnImageUrl().
+   * Variant fields (large/medium/small/tiny) are gone — VWA-131's
+   * CloudFront image-handler generates them on demand.
+   */
   original: string
-  medium: string
-  large: string
-  small: string
-  tiny: string
   post_id: number
   UserId: number
   height: number


### PR DESCRIPTION
## Summary

Companion to backend [VWA-133](https://linear.app/vwanu/issue/VWA-133). Drops the `large/medium/small/tiny` fields from the `Media` interface in `types.d.ts` since those columns are gone from the DB.

[VWA-133](https://linear.app/vwanu/issue/VWA-133) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)
Backend companion: [vwanu-api#66](https://github.com/Vwanu/vwanu-api/pull/66)

## Why no further mobile changes

`cdnImageUrl(item.original, preset)` from VWA-132 already handles both:
- A bare key (`posts/.../foo.jpg`) → builds the CloudFront URL with the requested transform
- A full S3 URL (legacy unmigrated row) → strips the bucket, treats as key
- An external URL (Cloudinary/UI-Avatars/Unsplash) → passes through

So once `media.original` switches from URL → key on the backend, mobile rendering keeps working without code change.

The one remaining stale read in the codebase is `item.profilePicture?.medium` in `sendInvitation.tsx` — it's behind a `typeof === 'string'` check that takes the right branch in practice, so it's already inert. Will get cleaned in [VWA-126](https://linear.app/vwanu/issue/VWA-126).

## Test plan

- [ ] Existing post media still renders in feed (cdnImageUrl handles both forms during rollout).
- [ ] After backend migration runs, new posts created via presign show their image (key form).
- [ ] Profile pictures still render on existing users (key form post-migration; UI-Avatars passthroughs unchanged).