### PR TITLE
VWA-128:Migrate community create/edit screen to presign + direct-S3 upload (FE)

### DIFF
--- a/src/screens/Communities/CreateCommunity.tsx
+++ b/src/screens/Communities/CreateCommunity.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react'
-import { View } from 'react-native'
+import React, { useMemo, useRef, useState } from 'react'
+import { View, TouchableOpacity, Image, ActivityIndicator } from 'react-native'
+import * as ImagePicker from 'expo-image-picker'
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 
@@ -7,13 +8,14 @@ import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import Screen from 'components/screen'
 import { CommunityStackParams, CommunityInterface } from '../../../types'
-import ImageUploadSection from '../../components/form/ImageUploadSection'
 import InterestSelector from '../../components/form/InterestSelector'
 import {
   useCreateCommunityMutation,
   useFetchCommunityQuery,
   useUpdateCommunityMutation,
 } from '../../store/communities-api-slice'
+import { useGetPresignedUploadUrlsMutation } from '../../store/uploads-api-slice'
+import { uploadToS3 } from '../../lib/uploadToS3'
 import { Field, Form } from 'components/form'
 import * as Yup from 'yup'
 import FormHeader from 'components/form/FormHeader'
@@ -23,6 +25,15 @@ import { isEqual } from 'lodash'
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { SerializedError } from '@reduxjs/toolkit'
 import PrivacySettings from './components/PrivacySettings'
+
+type UploadStatus = 'idle' | 'uploading' | 'done' | 'error'
+
+const inferMime = (filename: string): string => {
+  const ext = filename.split('.').pop()?.toLowerCase()
+  if (ext === 'png') return 'image/png'
+  if (ext === 'webp') return 'image/webp'
+  return 'image/jpeg'
+}
 
 type NavigationProp = StackNavigationProp<
   CommunityStackParams,
@@ -37,7 +48,6 @@ type CreateCommunityRouteProp = RouteProp<
 const ValidationSchema = Yup.object().shape({
   name: Yup.string().required('Name is required'),
   description: Yup.string().required('Description is required'),
-  profilePicture: Yup.string().nullable(),
   interests: Yup.array()
     .of(Yup.string().required())
     .min(1, 'Please select at least one interest')
@@ -72,6 +82,56 @@ const CreateCommunity = () => {
     useCreateCommunityMutation()
   const [updateCommunity, { isLoading: isUpdating, error: updateError }] =
     useUpdateCommunityMutation()
+  const [getPresignedUploadUrls] = useGetPresignedUploadUrlsMutation()
+
+  // Picture upload state — owned outside Formik so the upload-on-pick
+  // lifecycle is decoupled from form values.
+  const existingPictureKeyOrUrl = existingCommunity?.profilePicture
+  const [previewUri, setPreviewUri] = useState<string | undefined>()
+  const [pictureKey, setPictureKey] = useState<string | undefined>()
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>('idle')
+  const abortRef = useRef<AbortController | null>(null)
+
+  const startPictureUpload = async (uri: string) => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const filename = uri.split('/').pop() || 'community.jpg'
+    const mimeType = inferMime(filename)
+
+    setUploadStatus('uploading')
+    try {
+      const { files } = await getPresignedUploadUrls({
+        files: [{ filename, mimeType, uploadType: 'community' }],
+      }).unwrap()
+      await uploadToS3(files[0].uploadUrl, uri, mimeType, {
+        signal: controller.signal,
+      })
+      setPictureKey(files[0].key)
+      setUploadStatus('done')
+    } catch (err: any) {
+      if (err?.name === 'AbortError') return
+      console.error('Community picture upload failed:', err)
+      setUploadStatus('error')
+    }
+  }
+
+  const handlePickPicture = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
+    if (status !== 'granted') return
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    })
+    if (result.canceled) return
+    const asset = result.assets[0]
+    setPreviewUri(asset.uri)
+    setPictureKey(undefined)
+    void startPictureUpload(asset.uri)
+  }
 
   // Unified loading and error states
   const isLoading = isEditMode ? isFetchingCommunity || isUpdating : isCreating
@@ -83,7 +143,6 @@ const CreateCommunity = () => {
       return {
         name: existingCommunity.name,
         description: existingCommunity.description,
-        profilePicture: existingCommunity.profilePicture || '',
         interests:
           existingCommunity.interests?.map((interest) =>
             interest.id.toString()
@@ -93,7 +152,6 @@ const CreateCommunity = () => {
     return {
       name: '',
       description: '',
-      profilePicture: '',
       interests: [],
     }
   }, [isEditMode, existingCommunity])
@@ -103,30 +161,26 @@ const CreateCommunity = () => {
     existingCommunity: CommunityInterface
   ) => {
     const changes: any = {}
-    // Compare name
     if (formData.name !== existingCommunity.name) {
       changes.name = formData.name
     }
-    // Compare description
     if (formData.description !== existingCommunity.description) {
       changes.description = formData.description
     }
-    // Compare profilePicture (form) with profilePicture (API)
-    if (formData.profilePicture !== existingCommunity.profilePicture) {
-      changes.profilePicture = formData.profilePicture
+    // Picture: only include if user picked a new one this session AND
+    // the upload completed. Stored as profilePictureKey; backend hook
+    // resolves to the persisted profilePicture column.
+    if (pictureKey) {
+      changes.profilePictureKey = pictureKey
     }
-    // Compare interests - extract IDs from existing community first
     const existingInterestIds =
       existingCommunity.interests?.map((i) => i.id.toString()) || []
     const formInterestIds = formData.interests || []
-
-    // Use lodash isEqual for deep array comparison (order-independent)
     if (
       !isEqual([...existingInterestIds].sort(), [...formInterestIds].sort())
     ) {
       changes.interests = formData.interests
     }
-
     return changes
   }
   const handleSubmit = async (formData: InferType<typeof ValidationSchema>) => {
@@ -140,8 +194,15 @@ const CreateCommunity = () => {
           setUnifiedError(err)
         })
     } else {
-      // @ts-ignore
-      await createCommunity(formData)
+      await createCommunity({
+        name: formData.name,
+        description: formData.description,
+        // The form holds interest IDs as strings; CommunityCreationProps types
+        // it as `Interest[]` but the API accepts the IDs and the existing
+        // codebase has long passed strings here.
+        interests: formData.interests as any,
+        profilePictureKey: pictureKey,
+      })
         .then((result) => {
           navigation.replace('CommunityDetail', {
             // @ts-ignore
@@ -174,7 +235,51 @@ const CreateCommunity = () => {
             <Text category="h6" style={tw`font-poppins-bold text-lg mb-2 mt-4`}>
               Community Image
             </Text>
-            <ImageUploadSection name="profilePicture" />
+            <View style={tw`flex items-center mb-4`}>
+              <TouchableOpacity
+                onPress={handlePickPicture}
+                disabled={uploadStatus === 'uploading'}
+                style={tw`w-32 h-32 rounded-full bg-gray-200 overflow-hidden flex justify-center items-center`}
+              >
+                {previewUri ? (
+                  <>
+                    <Image
+                      source={{ uri: previewUri }}
+                      style={tw`w-full h-full`}
+                    />
+                    {uploadStatus === 'uploading' && (
+                      <View
+                        style={tw`absolute inset-0 bg-black bg-opacity-50 flex justify-center items-center`}
+                      >
+                        <ActivityIndicator color="#fff" />
+                      </View>
+                    )}
+                    {uploadStatus === 'error' && (
+                      <View
+                        style={tw`absolute inset-0 bg-red-500 bg-opacity-70 flex justify-center items-center`}
+                      >
+                        <Text style={tw`text-white font-bold text-xs`}>
+                          Tap to retry
+                        </Text>
+                      </View>
+                    )}
+                  </>
+                ) : existingPictureKeyOrUrl ? (
+                  // Renders existing community picture in edit mode. Once
+                  // VWA-132's cdnImageUrl helper lands in the parent branch,
+                  // wrap this in cdnImageUrl(...) for resized + face-cropped
+                  // delivery via CloudFront.
+                  <Image
+                    source={{ uri: existingPictureKeyOrUrl }}
+                    style={tw`w-full h-full`}
+                  />
+                ) : (
+                  <Text style={tw`text-gray-500 text-xs px-2 text-center`}>
+                    Tap to add image
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
 
             <Text category="h6" style={tw`font-poppins-bold text-lg mb-3 mt-4`}>
               Basic Information

--- a/src/store/communities-api-slice.ts
+++ b/src/store/communities-api-slice.ts
@@ -17,43 +17,29 @@ interface FetchCommunitiesParams {
 }
 
 type CommunityCreationProps = Partial<CommunityInterface> & {
-  profilePicture?: string
+  /**
+   * S3 key (from /uploads/presign with uploadType: 'community') of the
+   * community profile picture. Backend's applyProfileMediaKeys hook
+   * resolves this into the persisted `profilePicture` column.
+   */
+  profilePictureKey?: string
 }
 
-const _toFormData = (values: Partial<CommunityCreationProps>): FormData => {
-  const formData = new FormData()
-  values.name && formData.append('name', values.name)
-  values.description && formData.append('description', values.description)
-  values.privacyType && formData.append('privacyType', values.privacyType)
-
-  if (values.interests) {
-    values.interests.forEach((interest) => {
-      formData.append('interests', interest.toString())
-    })
+// Strip undefined fields and ensure interests are JSON-encoded as strings.
+// The backend now accepts JSON for community create/patch; multipart upload
+// is gone (VWA-128).
+const buildBody = (values: Partial<CommunityCreationProps>) => {
+  const body: Record<string, unknown> = {}
+  if (values.name !== undefined) body.name = values.name
+  if (values.description !== undefined) body.description = values.description
+  if (values.privacyType !== undefined) body.privacyType = values.privacyType
+  if (values.interests !== undefined) {
+    body.interests = values.interests.map((i) => i.toString())
   }
-
-  if (values.profilePicture) {
-    const filename =
-      values.profilePicture.split('/').pop() || 'profilePicture.jpg'
-    let mimeType = 'image/jpeg' // default
-
-    // Determine mime type based on file extension
-    if (filename.endsWith('.png')) {
-      mimeType = 'image/png'
-    } else if (filename.endsWith('.gif')) {
-      mimeType = 'image/gif'
-    } else if (filename.endsWith('.webp')) {
-      mimeType = 'image/webp'
-    }
-
-    const imageBlob = {
-      uri: values.profilePicture,
-      type: mimeType,
-      name: filename,
-    } as any
-    formData.append('profilePicture', imageBlob)
+  if (values.profilePictureKey !== undefined) {
+    body.profilePictureKey = values.profilePictureKey
   }
-  return formData
+  return body
 }
 
 // Community API endpoints
@@ -64,18 +50,11 @@ export const communitiesApiSlice = apiSlice.injectEndpoints({
       CommunityInterface,
       Partial<CommunityCreationProps>
     >({
-      query: (communityData) => {
-        const formData = _toFormData(communityData)
-        return {
-          url: '/communities',
-          method: HttpMethods.POST,
-          body: formData,
-          prepareHeaders: (headers: Headers) => {
-            headers.set('Content-Type', 'multipart/form-data')
-            return headers
-          },
-        }
-      },
+      query: (communityData) => ({
+        url: '/communities',
+        method: HttpMethods.POST,
+        body: buildBody(communityData),
+      }),
       invalidatesTags: ['Community'],
     }),
 
@@ -125,18 +104,11 @@ export const communitiesApiSlice = apiSlice.injectEndpoints({
       CommunityInterface,
       Partial<CommunityCreationProps> & { id: string }
     >({
-      query: ({ id, ...data }) => {
-        const formData = _toFormData(data)
-        return {
-          url: `/communities/${id}`,
-          method: 'PATCH',
-          body: formData,
-          prepareHeaders: (headers: Headers) => {
-            headers.set('Content-Type', 'multipart/form-data')
-            return headers
-          },
-        }
-      },
+      query: ({ id, ...data }) => ({
+        url: `/communities/${id}`,
+        method: 'PATCH',
+        body: buildBody(data),
+      }),
       invalidatesTags: (result, error, { id }) => [{ type: 'Community', id }],
     }),
 


### PR DESCRIPTION
## Summary

Rewrites the `CreateCommunity` screen to upload the community picture eagerly via the presign + direct-S3 flow (mirrors VWA-127's profile picture pattern). Replaces the multipart `_toFormData` helper in `communities-api-slice.ts` with a JSON `buildBody` that ships `profilePictureKey` instead of a file blob.

[VWA-128](https://linear.app/vwanu/issue/VWA-128) · stacks on [#154 (VWA-130 FE)](https://github.com/Vwanu/vwanu-mobile-application/pull/154) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

Backend companion: opening on `vwanu-api` shortly.

## What changed

- **`src/store/communities-api-slice.ts`** — removed `_toFormData`. `createCommunity` and `updateCommunity` now POST/PATCH JSON. `CommunityCreationProps` field renamed `profilePicture: string` → `profilePictureKey: string`.
- **`src/screens/Communities/CreateCommunity.tsx`** — replaced `<ImageUploadSection>` with local React state + `expo-image-picker` + `useGetPresignedUploadUrlsMutation` + `uploadToS3`. Picture uploads on pick, with loading spinner / error overlay; submit button picks up the resolved key.

## UX

- Tap circle → image picker → preview appears with spinner overlay during upload.
- Upload error → red overlay with "Tap to retry".
- Edit mode shows the existing picture (raw URL render for now; once VWA-132's `cdnImageUrl` helper is in the parent branch, swap to use it for resized + face-cropped delivery).
- Submit ships `profilePictureKey` only when an upload completed this session — empty key in edit mode means "don't change the picture".

## Test plan

- [ ] Create new community: tap circle, pick image, wait for spinner to clear, fill rest of form, submit → community visible in list with image.
- [ ] Create with no picture → community created, no picture set.
- [ ] Edit community: pick a different image → submit → picture updates.
- [ ] Edit community without touching picture → other fields update, picture unchanged.
- [ ] Network failure mid-upload → red retry overlay → tap to retry → completes.

## Out of scope

- Cover picture for communities — backend supports it via `coverPictureKey`, but the screen has no cover-picture UI today. Add when product wants it.
- Render existing community picture via `cdnImageUrl` in edit mode — defer until VWA-132 is in the parent branch (annotated TODO in the diff).