### PR TITLE
Hotfix:Render profile + community pictures via cdnImageUrl (post-VWA-127/128/133)

### DIFF
--- a/src/screens/Communities/components/CommunityGridCard.tsx
+++ b/src/screens/Communities/components/CommunityGridCard.tsx
@@ -15,6 +15,7 @@ import {
   useUpdateCommunityInvitationMutation,
 } from 'store/communities-api-slice'
 import { ActivityIndicator } from 'react-native-paper'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 type NavigationProp = StackNavigationProp<CommunityStackParams, 'Communities'>
 
@@ -87,10 +88,17 @@ const CommunityGridCard: React.FC<Props> = ({
       : tw`text-white text-2xl font-bold mb-2 leading-6`
   }, [size])
 
+  if (!community) return null
+
   return (
     <TouchableOpacity style={[computeStyle, style]} onPress={handlePress}>
       <ImageBackground
-        source={{ uri: community?.profilePicture }}
+        source={{
+          uri: cdnImageUrl(community?.profilePicture, {
+            width: 600,
+            height: 600,
+          }),
+        }}
         style={tw`w-full h-full`}
         resizeMode="cover"
       >
@@ -146,7 +154,7 @@ const CommunityGridCard: React.FC<Props> = ({
               showShowMoreText={size === 'extra-small' ? false : true}
             />
 
-            {size !== 'extra-small' ? (
+            {size !== 'extra-small' && community?.description ? (
               <LongText
                 text={community.description}
                 maxLength={size === 'small' ? 10 : 150}
@@ -158,7 +166,9 @@ const CommunityGridCard: React.FC<Props> = ({
 
             <View style={tw`flex-row items-center justify-between mt-5`}>
               <View style={tw`flex-row items-center`}>
-                <AvatarGroup avatars={community.members || []} size={25} />
+                {community?.members && (
+                  <AvatarGroup avatars={community.members} size={25} />
+                )}
                 {amountOfMembers && (
                   <Text style={tw`text-white text-xs ml-2`}>
                     {amountOfMembers < 100

--- a/src/screens/Communities/components/FeaturedCommunityCard.tsx
+++ b/src/screens/Communities/components/FeaturedCommunityCard.tsx
@@ -7,6 +7,7 @@ import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import AvatarGroup from 'components/AvatarGroups'
 import { CommunityStackParams, CommunityInterface } from '../../../../types'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 type NavigationProp = StackNavigationProp<CommunityStackParams, 'Communities'>
 
@@ -37,7 +38,12 @@ const FeaturedCommunityCard: React.FC<Props> = ({
       onPress={handlePress}
     >
       <ImageBackground
-        source={{ uri: community.profilePicture }}
+        source={{
+          uri: cdnImageUrl(community.profilePicture, {
+            width: 800,
+            height: 800,
+          }),
+        }}
         style={tw`w-full h-full`}
         resizeMode="cover"
       >

--- a/src/screens/Profile/ProfileHeader.tsx
+++ b/src/screens/Profile/ProfileHeader.tsx
@@ -21,6 +21,7 @@ import { useFetchUnreadNotificationsQuery } from 'store/notifications-api-slice'
 
 import useToggle from 'hooks/useToggle'
 import ProfileStats from './ProfileStats'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 interface ProfileHeaderProps {
   profileId: string
@@ -107,7 +108,13 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = (props) => {
           {user.profilePicture ? (
             <PaperAvatar.Image
               size={64}
-              source={{ uri: user.profilePicture }}
+              source={{
+                uri: cdnImageUrl(user.profilePicture, {
+                  width: 128, // 2x for retina
+                  height: 128,
+                  smartCrop: true,
+                }),
+              }}
             />
           ) : (
             <Text style={tw`text-white font-poppins-bold text-lg`}>


### PR DESCRIPTION
## Summary

Three post-merge bugs found during smoke testing of the upload migration wave (VWA-127/128/130/131/132/133/137).

Backend companion (drops the \`isUrl\` validator on \`Community.profilePicture\`): opening on \`vwanu-api\` next.

## Bugs fixed

### 1. Profile picture not rendering on profile page

\`ProfileHeader.tsx\` rendered \`user.profilePicture\` (now a bare S3 key, post-VWA-133) directly into \`<Avatar.Image>\`, producing a broken \`profiles/.../foo.jpg\` URI. Fix: wrap with \`cdnImageUrl(..., { width: 128, height: 128, smartCrop: true })\`.

### 2. Community grid + featured cards not rendering

Same problem in \`CommunityGridCard.tsx\` and \`FeaturedCommunityCard.tsx\` \`<ImageBackground>\`. Fixes:
- \`CommunityGridCard\` → \`cdnImageUrl(..., { width: 600, height: 600 })\`
- \`FeaturedCommunityCard\` → \`cdnImageUrl(..., { width: 800, height: 800 })\`

### 3. Community grid crashes "cannot read property 'description' of undefined"

Pre-existing missing optional chain in \`CommunityGridCard\`, exposed by a freshly-created community whose description hadn't loaded yet. Guard with truthiness:

\`\`\`tsx
{size !== 'extra-small' && community?.description ? (
  <LongText text={community.description} ... />
) : null}
\`\`\`

## Why this slipped past the per-surface PRs

VWA-127/128 only changed the **write** side. VWA-132 wired \`cdnImageUrl\` into \`ProfAvatar\` and \`ImageGrid\`. The components touched here read the picture column via their own \`<Image>\` / \`<Avatar>\` calls — not in the original sweep.

## Test plan

- [ ] Sign up new user → upload profile picture → submit → open profile → avatar renders via CloudFront.
- [ ] Open Communities tab → grid renders with images, no crash on cards without description.
- [ ] Existing communities with old multipart-uploaded URLs still render (cdnImageUrl passthrough).