### PR TITLE
VWa 129 : migrate cover picture to presign + direct-S3 upload 

### DIFF
--- a/src/components/form/ImageUploadSection.tsx
+++ b/src/components/form/ImageUploadSection.tsx
@@ -11,12 +11,20 @@ interface Props {
   name: string
   label?: string
   helperText?: string
+  /**
+   * Fires with the freshly-picked local file URI whenever the user
+   * selects (or retakes) an image. Use this to kick off the presign +
+   * S3 upload from the parent (the Formik field value still gets
+   * updated for preview rendering).
+   */
+  onImagePicked?: (uri: string) => void
 }
 
 const ImageUploadSection: React.FC<Props> = ({
   name,
   label = 'Community Image',
   helperText,
+  onImagePicked,
 }) => {
   const [imageUri, setImageUri] = useState<string | null>(null)
   const { setFieldValue, values } = useFormikContext()
@@ -31,6 +39,7 @@ const ImageUploadSection: React.FC<Props> = ({
   const onImageSelected = (uri: string) => {
     setImageUri(uri)
     setFieldValue(name, uri)
+    onImagePicked?.(uri)
   }
   const handleImagePicker = async () => {
     try {

--- a/src/screens/blogs/BlogDetatails.screen.tsx/Header.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, TouchableOpacity, Alert } from 'react-native'
+import { View, TouchableOpacity, Alert, Dimensions } from 'react-native'
 import { ImageBackground } from 'expo-image'
 import { Ionicons } from '@expo/vector-icons'
 import { Popover } from '@ui-kitten/components'
@@ -22,6 +22,7 @@ import {
   useUpdateBlogMutation,
   useToggleBlogLikeMutation,
 } from '../../../store/blog-api-slice'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 interface Props {
   blog: Blog
@@ -30,6 +31,7 @@ interface Props {
 }
 
 const BlogHeader: React.FC<Props> = ({ blog, onShowContent, showContent }) => {
+  const screenWidth = Dimensions.get('window').width
   const [toggleBlogLike] = useToggleBlogLikeMutation()
   const handleLike = async (id: string) => {
     await toggleBlogLike(id).unwrap()
@@ -102,7 +104,10 @@ const BlogHeader: React.FC<Props> = ({ blog, onShowContent, showContent }) => {
   return (
     <View>
       <ImageBackground
-        source={{ uri: blog.titlePicture }}
+        source={cdnImageUrl(blog.titlePicture, {
+          width: screenWidth,
+          height: 350,
+        })}
         style={tw`w-full h-[350px] rounded-b-3xl overflow-hidden`}
         contentFit="cover"
       >

--- a/src/screens/blogs/CreateBlog.screen/BlogImageInterest.tsx
+++ b/src/screens/blogs/CreateBlog.screen/BlogImageInterest.tsx
@@ -25,12 +25,19 @@ interface BlogImage {
   formRef?: React.Ref<FormikProps<any>>
   onSubmit: (values: typeof initialValues) => void
   values?: typeof initialValues
+  /**
+   * Fires with the freshly-picked local file URI. The parent owns the
+   * upload lifecycle and only sends the resulting titlePictureKey on
+   * final submit — the Formik field value here is preview-only.
+   */
+  onImagePicked?: (uri: string) => void
 }
 
 const BlogImageInterest: React.FC<BlogImage> = ({
   formRef,
   onSubmit,
   values,
+  onImagePicked,
 }) => {
   if (values) {
     initialValues = values
@@ -51,6 +58,7 @@ const BlogImageInterest: React.FC<BlogImage> = ({
           name="titlePicture"
           label="Cover Image"
           helperText="Tap to upload a cover image for your blog"
+          onImagePicked={onImagePicked}
         />
 
         <View style={tw`px-4 py-6`}>

--- a/src/screens/blogs/CreateBlog.screen/index.tsx
+++ b/src/screens/blogs/CreateBlog.screen/index.tsx
@@ -9,6 +9,7 @@ import Screen from 'components/screen'
 import Button from 'components/Button'
 import AppCloseBtn from 'components/AppCloseBtn'
 import Toast, { ToastType } from 'components/Toast'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 import { FeedStackParams, CreateBlogParams } from '../../../../types'
 import { Ionicons } from '@expo/vector-icons'
 import {
@@ -16,10 +17,22 @@ import {
   useUpdateBlogMutation,
   useFetchBlogQuery,
 } from '../../../store/blog-api-slice'
+import { useGetPresignedUploadUrlsMutation } from '../../../store/uploads-api-slice'
+import { uploadToS3 } from '../../../lib/uploadToS3'
 import BlogContent from './BlogContent'
 import BlogImageInterest from './BlogImageInterest'
 
 type NavigationProp = StackNavigationProp<FeedStackParams, 'CreateBlog'>
+
+type UploadStatus = 'idle' | 'uploading' | 'done' | 'error'
+
+const inferMime = (filename: string): string => {
+  const ext = filename.split('.').pop()?.toLowerCase()
+  if (ext === 'png') return 'image/png'
+  if (ext === 'webp') return 'image/webp'
+  if (ext === 'gif') return 'image/gif'
+  return 'image/jpeg'
+}
 
 const CreateBlogScreen = () => {
   const formRef = useRef<FormikProps<any>>(null)
@@ -47,13 +60,25 @@ const CreateBlogScreen = () => {
 
   const [createBlog, { isLoading: isCreating }] = useCreateBlogMutation()
   const [updateBlog, { isLoading: isUpdating }] = useUpdateBlogMutation()
+  const [getPresignedUploadUrls] = useGetPresignedUploadUrlsMutation()
   const isSubmitting = isCreating || isUpdating
 
-  // Pre-fill form values when editing an existing blog
+  // Picture upload state — owned outside Formik so the upload lifecycle
+  // survives the step 0 ↔ step 1 transitions. Mirrors the pattern in
+  // CreateCommunity.tsx (VWA-128).
+  const [pictureKey, setPictureKey] = useState<string | undefined>()
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>('idle')
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Pre-fill form values when editing an existing blog. Cover preview goes
+  // through cdnImageUrl so the bare S3 key (VWA-133) renders via CloudFront.
+  // Note: we don't seed pictureKey from existingBlog.titlePicture — the
+  // patch payload should only include titlePictureKey when the user picks
+  // a new image; otherwise the server keeps the existing column value.
   useEffect(() => {
     if (existingBlog) {
       setStep1Values({
-        titlePicture: existingBlog.titlePicture,
+        titlePicture: cdnImageUrl(existingBlog.titlePicture, 'large') ?? '',
         interests: existingBlog.interests?.map((i) => i.id) || [],
       })
       setContentValues({
@@ -63,17 +88,69 @@ const CreateBlogScreen = () => {
     }
   }, [existingBlog])
 
+  const startPictureUpload = async (uri: string) => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const filename = uri.split('/').pop() || 'titlePicture.jpg'
+    const mimeType = inferMime(filename)
+
+    setUploadStatus('uploading')
+    try {
+      const { files } = await getPresignedUploadUrls({
+        files: [{ filename, mimeType, uploadType: 'blog' }],
+      }).unwrap()
+      await uploadToS3(files[0].uploadUrl, uri, mimeType, {
+        signal: controller.signal,
+      })
+      setPictureKey(files[0].key)
+      setUploadStatus('done')
+    } catch (err: any) {
+      if (err?.name === 'AbortError') return
+      console.error('Blog cover upload failed:', err)
+      setUploadStatus('error')
+    }
+  }
+
+  const handleImagePicked = (uri: string) => {
+    setPictureKey(undefined)
+    void startPictureUpload(uri)
+  }
+
   const handleSubmit = async (value: any) => {
     if (step === 1) {
-      const allData: CreateBlogParams = {
-        ...step1Values,
-        ...value,
+      // Block submit if a picture is mid-upload or errored. We deliberately
+      // don't block when no picture was picked at all (cover is optional).
+      if (uploadStatus === 'uploading') {
+        setToast({
+          visible: true,
+          type: 'info',
+          message: 'Cover image is still uploading — try again in a moment.',
+        })
+        return
       }
+      if (uploadStatus === 'error') {
+        setToast({
+          visible: true,
+          type: 'error',
+          message: 'Cover image upload failed. Pick a new image to retry.',
+        })
+        return
+      }
+
+      const payload: CreateBlogParams = {
+        title: value.title,
+        content: value.content,
+        interests: (step1Values?.interests ?? []) as string[],
+        ...(pictureKey ? { titlePictureKey: pictureKey } : {}),
+      }
+
       try {
         if (isEditing) {
-          await updateBlog({ id: blogId, ...allData }).unwrap()
+          await updateBlog({ id: blogId, ...payload }).unwrap()
         } else {
-          await createBlog(allData).unwrap()
+          await createBlog(payload).unwrap()
         }
         setToast({
           visible: true,
@@ -93,7 +170,7 @@ const CreateBlogScreen = () => {
               typeof error.data === 'string'
                 ? JSON.parse(error.data)
                 : error.data
-            message = parsed.error || message
+            message = parsed.error || parsed.message || message
           } catch {
             // use default message
           }
@@ -156,6 +233,7 @@ const CreateBlogScreen = () => {
             formRef={formRef}
             onSubmit={handleSubmit}
             values={step1Values}
+            onImagePicked={handleImagePicked}
           />
         ) : (
           <BlogContent

--- a/src/screens/blogs/components/BlogCard.tsx
+++ b/src/screens/blogs/components/BlogCard.tsx
@@ -13,6 +13,7 @@ import Text from 'components/Text'
 import LikeForm from 'components/LikeForm'
 import { Blog } from '../../../../types'
 import { useToggleBlogLikeMutation } from 'store/blog-api-slice'
+import { cdnImageUrl } from 'lib/cdnImageUrl'
 
 interface BlogCardProps {
   blog: Blog
@@ -63,7 +64,12 @@ const BlogCard: React.FC<BlogCardProps> = ({ blog, onPress }) => {
         <View style={tw`flex-row items-center`}>
           <View style={tw`w-[100px] h-[100px] p-2`}>
             <Image
-              source={{ uri: blog.titlePicture }}
+              source={{
+                uri: cdnImageUrl(blog.titlePicture, {
+                  width: 200,
+                  height: 200,
+                }),
+              }}
               style={tw`w-full h-[100%] rounded-lg`}
             />
           </View>

--- a/src/store/blog-api-slice.ts
+++ b/src/store/blog-api-slice.ts
@@ -1,6 +1,5 @@
 import apiSlice from './api-slice'
 import { endpoints, HttpMethods } from '../config'
-import { AuthTokenService } from '../lib/authTokenService'
 import {
   Blog,
   BlogComment,
@@ -10,47 +9,22 @@ import {
   UpdateBlogParams,
 } from '../../types'
 
-const _toFormData = (
+// Strip undefined fields. The backend now accepts JSON for blog create/patch;
+// multipart upload is gone (VWA-129). Title picture lands via presign +
+// titlePictureKey; backend's applyBlogMediaKeys hook resolves to the
+// persisted titlePicture column.
+const buildBody = (
   values: Partial<CreateBlogParams & Pick<UpdateBlogParams, 'publishedAt'>>
-): FormData => {
-  const formData = new FormData()
-
-  if (values.title) formData.append('title', values.title)
-  if (values.content) formData.append('content', values.content)
-  if ('publishedAt' in values) {
-    formData.append(
-      'publishedAt',
-      values.publishedAt === null ? '' : values.publishedAt!
-    )
+) => {
+  const body: Record<string, unknown> = {}
+  if (values.title !== undefined) body.title = values.title
+  if (values.content !== undefined) body.content = values.content
+  if ('publishedAt' in values) body.publishedAt = values.publishedAt
+  if (values.interests !== undefined) body.interests = values.interests
+  if (values.titlePictureKey !== undefined) {
+    body.titlePictureKey = values.titlePictureKey
   }
-
-  if (values.interests) {
-    values.interests.forEach((interest) => {
-      formData.append('interests', interest)
-    })
-  }
-
-  if (values.titlePicture) {
-    const filename = values.titlePicture.split('/').pop() || 'titlePicture.jpg'
-    let mimeType = 'image/jpeg'
-
-    if (filename.endsWith('.png')) {
-      mimeType = 'image/png'
-    } else if (filename.endsWith('.gif')) {
-      mimeType = 'image/gif'
-    } else if (filename.endsWith('.webp')) {
-      mimeType = 'image/webp'
-    }
-
-    const imageBlob = {
-      uri: values.titlePicture,
-      type: mimeType,
-      name: filename,
-    } as any
-    formData.append('titlePicture', imageBlob)
-  }
-
-  return formData
+  return body
 }
 
 export const blogApiSlice = apiSlice.injectEndpoints({
@@ -111,125 +85,21 @@ export const blogApiSlice = apiSlice.injectEndpoints({
 
     // Create a new blog
     createBlog: builder.mutation<Blog, CreateBlogParams>({
-      async queryFn(blogData) {
-        try {
-          const formData = _toFormData(blogData)
-          const tokens = await AuthTokenService.getValidTokens()
-          const baseUrl = process.env.EXPO_PUBLIC_API_URL?.trim()
-          const appKey = process.env.EXPO_PUBLIC_APP_KEY
-
-          const headers: Record<string, string> = {}
-          if (tokens?.accessToken) {
-            headers['authorization'] = `Bearer ${tokens.accessToken}`
-          }
-          if (tokens?.idToken) {
-            headers['x-id-token'] = tokens.idToken
-          }
-          if (appKey) {
-            headers['x-app-key'] = appKey
-          }
-
-          const controller = new AbortController()
-          const timeoutId = setTimeout(() => controller.abort(), 30000)
-
-          console.log(
-            '📤 Sending blog POST to:',
-            `${baseUrl}${endpoints.BLOGS}`
-          )
-
-          const response = await fetch(`${baseUrl}${endpoints.BLOGS}`, {
-            method: 'POST',
-            headers,
-            body: formData,
-            signal: controller.signal,
-          })
-
-          clearTimeout(timeoutId)
-
-          console.log('📥 Blog POST response status:', response.status)
-
-          if (!response.ok) {
-            const errorText = await response.text()
-            console.error('❌ Blog POST error body:', errorText)
-            return {
-              error: {
-                status: response.status,
-                data: errorText,
-              },
-            }
-          }
-
-          const data = await response.json()
-          console.log('✅ Blog created successfully:', data.id)
-          return { data: data as Blog }
-        } catch (err: any) {
-          console.error('❌ Blog POST exception:', err.name, err.message)
-          return {
-            error: {
-              status: 'FETCH_ERROR',
-              error: err.message || 'Failed to create blog',
-            },
-          }
-        }
-      },
+      query: (blogData) => ({
+        url: endpoints.BLOGS,
+        method: HttpMethods.POST,
+        body: buildBody(blogData),
+      }),
       invalidatesTags: [{ type: 'Blog', id: 'LIST' }],
     }),
 
     // Update an existing blog
     updateBlog: builder.mutation<Blog, UpdateBlogParams>({
-      async queryFn({ id, ...data }) {
-        try {
-          const formData = _toFormData(data)
-          const tokens = await AuthTokenService.getValidTokens()
-          const baseUrl = process.env.EXPO_PUBLIC_API_URL?.trim()
-          const appKey = process.env.EXPO_PUBLIC_APP_KEY
-
-          const headers: Record<string, string> = {}
-          if (tokens?.accessToken) {
-            headers['authorization'] = `Bearer ${tokens.accessToken}`
-          }
-          if (tokens?.idToken) {
-            headers['x-id-token'] = tokens.idToken
-          }
-          if (appKey) {
-            headers['x-app-key'] = appKey
-          }
-
-          const controller = new AbortController()
-          const timeoutId = setTimeout(() => controller.abort(), 30000)
-
-          const response = await fetch(`${baseUrl}${endpoints.BLOGS}/${id}`, {
-            method: 'PATCH',
-            headers,
-            body: formData,
-            signal: controller.signal,
-          })
-
-          clearTimeout(timeoutId)
-
-          if (!response.ok) {
-            const errorText = await response.text()
-            console.error('❌ Blog PATCH error body:', errorText)
-            return {
-              error: {
-                status: response.status,
-                data: errorText,
-              },
-            }
-          }
-
-          const responseData = await response.json()
-          return { data: responseData as Blog }
-        } catch (err: any) {
-          console.error('❌ Blog PATCH exception:', err.name, err.message)
-          return {
-            error: {
-              status: 'FETCH_ERROR',
-              error: err.message || 'Failed to update blog',
-            },
-          }
-        }
-      },
+      query: ({ id, ...data }) => ({
+        url: `${endpoints.BLOGS}/${id}`,
+        method: HttpMethods.PATCH,
+        body: buildBody(data),
+      }),
       invalidatesTags: (result, error, { id }) => [
         { type: 'Blog', id },
         { type: 'Blog', id: 'LIST' },

--- a/types.d.ts
+++ b/types.d.ts
@@ -351,7 +351,12 @@ export interface FetchBlogsParams {
 export interface CreateBlogParams {
   title: string
   content: string
-  titlePicture?: string
+  /**
+   * S3 key (from /uploads/presign with uploadType: 'blog') of the
+   * blog cover picture. Backend's applyBlogMediaKeys hook resolves
+   * this into the persisted `titlePicture` column.
+   */
+  titlePictureKey?: string
   interests: string[]
 }
 
@@ -359,7 +364,7 @@ export interface UpdateBlogParams {
   id: string
   title?: string
   content?: string
-  titlePicture?: string
+  titlePictureKey?: string
   interests?: string[]
   publishedAt?: string | null
 }


### PR DESCRIPTION
…-129)

Rips the FormData/queryFn upload path from blog-api-slice in favor of plain JSON mutations carrying titlePictureKey. CreateBlog screen now owns the presign + uploadToS3 lifecycle (mirroring CreateCommunity from VWA-128), and edit-mode previews render through cdnImageUrl since the DB column now stores bare S3 keys (VWA-133).