### PR TITLE
chore(ci): enable CodeRabbit auto-review for qa/cycle-* PRs (VWA-147)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ auto-review:
   scope:
     # Use standard globbing where '*' acts as the wildcard flag
     base_branches:
-      - "qa/cycle*"
+      - "qa/cycle-*"
 reviews:
   auto_title_instructions: |
     Generate a concise, descriptive PR title based on the changes in this pull request.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,10 @@
+version: 1
+auto-review:
+  enabled: true
+  scope:
+    # Use standard globbing where '*' acts as the wildcard flag
+    base_branches:
+      - "qa/cycle*"
 reviews:
   auto_title_instructions: |
     Generate a concise, descriptive PR title based on the changes in this pull request.


### PR DESCRIPTION
Prepends the auto-review block to the existing .coderabbit.yaml so any PR targeting a qa/cycle-* base branch is automatically reviewed by CodeRabbit. The existing auto_title_instructions block is preserved.