### PR TITLE
VWA-154:Single blog reading redesign

### DIFF
--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogHero.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogHero.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
-import tw from 'lib/tailwind'
-import Text from 'components/Text'
 import CoverHero from '../CreateBlog.screen/BlogContent/CoverHero'
 import { Blog } from '../../../../types'
 import HeroActionBar from './HeroActionBar'
+import BlogTitle from './BlogTitle'
 
 interface Props {
   blog: Blog
@@ -18,15 +17,7 @@ const BlogHero: React.FC<Props> = ({ blog, onClose }) => (
     headerComponent={
       <HeroActionBar onClose={onClose} isDraft={!blog.publishedAt} />
     }
-    titleComponent={
-      <Text
-        style={tw`text-3xl font-syne-bold text-white`}
-        numberOfLines={2}
-        ellipsizeMode="tail"
-      >
-        {blog.title}
-      </Text>
-    }
+    titleComponent={<BlogTitle title={blog.title} />}
   />
 )
 

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogHero.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogHero.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import tw from 'lib/tailwind'
+import Text from 'components/Text'
+import CoverHero from '../CreateBlog.screen/BlogContent/CoverHero'
+import { Blog } from '../../../../types'
+import HeroActionBar from './HeroActionBar'
+
+interface Props {
+  blog: Blog
+  onClose: () => void
+}
+
+const BlogHero: React.FC<Props> = ({ blog, onClose }) => (
+  <CoverHero
+    coverImage={blog.titlePicture}
+    interests={blog.interests || []}
+    headerComponent={
+      <HeroActionBar onClose={onClose} isDraft={!blog.publishedAt} />
+    }
+    titleComponent={
+      <Text
+        style={tw`text-3xl font-syne-bold text-white`}
+        numberOfLines={2}
+        ellipsizeMode="tail"
+      >
+        {blog.title}
+      </Text>
+    }
+  />
+)
+
+export default BlogHero

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogMetaBar.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogMetaBar.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { View, TouchableOpacity } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { formatDate } from 'date-fns'
+
+import tw from 'lib/tailwind'
+import Text from 'components/Text'
+import ProfAvatar from 'components/ProfAvatar'
+import LikeForm from 'components/LikeForm'
+import { Blog } from '../../../../types'
+
+interface Props {
+  blog: Blog
+  content: boolean
+  onToggle: () => void
+  onLike: (id: string) => Promise<void>
+}
+
+const BlogMetaBar: React.FC<Props> = ({ blog, content, onToggle, onLike }) => {
+  const formattedDate = blog.publishedAt
+    ? formatDate(new Date(blog.publishedAt), 'MMMM dd, yyyy')
+    : 'Draft'
+
+  return (
+    <View style={tw`p-4`}>
+      <View style={tw`flex-row items-center justify-between`}>
+        <ProfAvatar user={blog.user} size={40} subtitle={formattedDate} />
+        <TouchableOpacity
+          style={tw`flex-row items-center align-center justify-center gap-1`}
+          onPress={onToggle}
+        >
+          {content && (
+            <Text style={tw`text-primary`}>{blog.amountOfComments ?? 0}</Text>
+          )}
+          <Ionicons
+            name={content ? 'chatbubble-ellipses-outline' : 'book-outline'}
+            color={tw.color('primary')}
+            size={20}
+          />
+        </TouchableOpacity>
+        <LikeForm
+          id={blog.id}
+          likersCount={blog.amountOfLikes}
+          isReactor={false}
+          size={28}
+          flexDir="row"
+          onLike={onLike}
+        />
+      </View>
+    </View>
+  )
+}
+
+export default BlogMetaBar

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogMetaBar.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogMetaBar.tsx
@@ -7,7 +7,9 @@ import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import ProfAvatar from 'components/ProfAvatar'
 import LikeForm from 'components/LikeForm'
+import { colors } from 'components/ui/tokens'
 import { Blog } from '../../../../types'
+import { getReadingStats } from '../utils/readingStats'
 
 interface Props {
   blog: Blog
@@ -18,34 +20,51 @@ interface Props {
 
 const BlogMetaBar: React.FC<Props> = ({ blog, content, onToggle, onLike }) => {
   const formattedDate = blog.publishedAt
-    ? formatDate(new Date(blog.publishedAt), 'MMMM dd, yyyy')
+    ? formatDate(new Date(blog.publishedAt), 'MMM d, yyyy')
     : 'Draft'
+  const { minutes } = getReadingStats(blog.content)
 
   return (
-    <View style={tw`p-4`}>
-      <View style={tw`flex-row items-center justify-between`}>
-        <ProfAvatar user={blog.user} size={40} subtitle={formattedDate} />
-        <TouchableOpacity
-          style={tw`flex-row items-center align-center justify-center gap-1`}
-          onPress={onToggle}
-        >
-          {content && (
-            <Text style={tw`text-primary`}>{blog.amountOfComments ?? 0}</Text>
-          )}
-          <Ionicons
-            name={content ? 'chatbubble-ellipses-outline' : 'book-outline'}
-            color={tw.color('primary')}
-            size={20}
-          />
-        </TouchableOpacity>
+    <View style={tw`px-4 py-3 flex-row items-center justify-between`}>
+      <View style={tw`flex-1 mr-3`}>
+        <ProfAvatar
+          user={blog.user}
+          size={40}
+          subtitle={`${formattedDate}  ·  ${minutes} min read`}
+        />
+      </View>
+
+      <View style={tw`flex-row items-center gap-2`}>
         <LikeForm
           id={blog.id}
           likersCount={blog.amountOfLikes}
           isReactor={false}
-          size={28}
+          size={24}
           flexDir="row"
           onLike={onLike}
         />
+        <TouchableOpacity
+          onPress={onToggle}
+          activeOpacity={0.85}
+          style={[
+            tw`flex-row items-center px-3 py-1.5 rounded-full`,
+            { backgroundColor: colors.primarySoft },
+          ]}
+        >
+          <Ionicons
+            name={content ? 'chatbubble-ellipses-outline' : 'book-outline'}
+            size={16}
+            color={colors.primaryDeep}
+          />
+          <Text
+            style={[
+              tw`ml-1 text-xs font-poppins-semibold`,
+              { color: colors.primaryDeep },
+            ]}
+          >
+            {content ? blog.amountOfComments ?? 0 : 'Read'}
+          </Text>
+        </TouchableOpacity>
       </View>
     </View>
   )

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogReadingView.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogReadingView.tsx
@@ -11,10 +11,10 @@ import Animated, {
 } from 'react-native-reanimated'
 
 import tw from 'lib/tailwind'
-import Text from 'components/Text'
 import { colors } from 'components/ui/tokens'
 import { Blog } from '../../../../types'
 import BlogHero from './BlogHero'
+import BlogTitle from './BlogTitle'
 import BlogMetaBar from './BlogMetaBar'
 import Body from './Body'
 
@@ -24,7 +24,7 @@ const COLLAPSE_DISTANCE = 120
 interface Props {
   blog: Blog
   content: boolean
-  onToggle: () => void
+  onToggle: (heroCollapsed: boolean) => void
   onLike: (id: string) => Promise<void>
   onClose: () => void
 }
@@ -41,6 +41,10 @@ const BlogReadingView: React.FC<Props> = ({
   const scrollHandler = useAnimatedScrollHandler((event) => {
     scrollY.value = event.contentOffset.y
   })
+
+  // Report whether the hero is collapsed when toggling, so the comment view
+  // can animate the cover back in only if it had vanished.
+  const handleToggle = () => onToggle(scrollY.value >= COLLAPSE_DISTANCE)
 
   const heroStyle = useAnimatedStyle(() => ({
     opacity: interpolate(
@@ -106,7 +110,7 @@ const BlogReadingView: React.FC<Props> = ({
           <BlogMetaBar
             blog={blog}
             content={content}
-            onToggle={onToggle}
+            onToggle={handleToggle}
             onLike={onLike}
           />
         </Animated.View>
@@ -126,21 +130,16 @@ const BlogReadingView: React.FC<Props> = ({
               <BlogMetaBar
                 blog={blog}
                 content={content}
-                onToggle={onToggle}
+                onToggle={handleToggle}
                 onLike={onLike}
               />
             </View>
           </View>
-          <Text
-            style={[
-              tw`px-4 pb-2 text-lg font-syne-bold`,
-              { color: colors.ink },
-            ]}
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          >
-            {blog.title}
-          </Text>
+          <BlogTitle
+            title={blog.title}
+            color={colors.ink}
+            style={tw`px-4 pb-2`}
+          />
         </SafeAreaView>
       </Animated.View>
     </View>

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogReadingView.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogReadingView.tsx
@@ -1,0 +1,150 @@
+import React from 'react'
+import { View, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Ionicons } from '@expo/vector-icons'
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated'
+
+import tw from 'lib/tailwind'
+import Text from 'components/Text'
+import { colors } from 'components/ui/tokens'
+import { Blog } from '../../../../types'
+import BlogHero from './BlogHero'
+import BlogMetaBar from './BlogMetaBar'
+import Body from './Body'
+
+// Scroll distance (px) over which the hero collapses into the sticky header.
+const COLLAPSE_DISTANCE = 120
+
+interface Props {
+  blog: Blog
+  content: boolean
+  onToggle: () => void
+  onLike: (id: string) => Promise<void>
+  onClose: () => void
+}
+
+const BlogReadingView: React.FC<Props> = ({
+  blog,
+  content,
+  onToggle,
+  onLike,
+  onClose,
+}) => {
+  const scrollY = useSharedValue(0)
+
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    scrollY.value = event.contentOffset.y
+  })
+
+  const heroStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      scrollY.value,
+      [0, COLLAPSE_DISTANCE],
+      [1, 0],
+      Extrapolation.CLAMP
+    ),
+    transform: [
+      {
+        translateY: interpolate(
+          scrollY.value,
+          [0, COLLAPSE_DISTANCE],
+          [0, -40],
+          Extrapolation.CLAMP
+        ),
+      },
+    ],
+  }))
+
+  // The in-scroll meta bar fades out before the sticky one fades in, so the two
+  // are never visible at the same time.
+  const inlineMetaStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      scrollY.value,
+      [0, COLLAPSE_DISTANCE * 0.5],
+      [1, 0],
+      Extrapolation.CLAMP
+    ),
+  }))
+
+  const compactStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      scrollY.value,
+      [COLLAPSE_DISTANCE * 0.5, COLLAPSE_DISTANCE],
+      [0, 1],
+      Extrapolation.CLAMP
+    ),
+    transform: [
+      {
+        translateY: interpolate(
+          scrollY.value,
+          [COLLAPSE_DISTANCE * 0.5, COLLAPSE_DISTANCE],
+          [-16, 0],
+          Extrapolation.CLAMP
+        ),
+      },
+    ],
+  }))
+
+  return (
+    <View style={tw`flex-1`}>
+      <Animated.ScrollView
+        onScroll={scrollHandler}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={tw`pb-10`}
+      >
+        <Animated.View style={heroStyle}>
+          <BlogHero blog={blog} onClose={onClose} />
+        </Animated.View>
+        <Animated.View style={inlineMetaStyle}>
+          <BlogMetaBar
+            blog={blog}
+            content={content}
+            onToggle={onToggle}
+            onLike={onLike}
+          />
+        </Animated.View>
+        <Body blog={blog} />
+      </Animated.ScrollView>
+
+      <Animated.View
+        style={[tw`absolute top-0 left-0 right-0 bg-warm-bg`, compactStyle]}
+        pointerEvents="box-none"
+      >
+        <SafeAreaView edges={['top']}>
+          <View style={tw`flex-row items-center px-2 pt-1`}>
+            <TouchableOpacity onPress={onClose} hitSlop={8} style={tw`p-2`}>
+              <Ionicons name="chevron-back" size={22} color={colors.ink} />
+            </TouchableOpacity>
+            <View style={tw`flex-1`}>
+              <BlogMetaBar
+                blog={blog}
+                content={content}
+                onToggle={onToggle}
+                onLike={onLike}
+              />
+            </View>
+          </View>
+          <Text
+            style={[
+              tw`px-4 pb-2 text-lg font-syne-bold`,
+              { color: colors.ink },
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {blog.title}
+          </Text>
+        </SafeAreaView>
+      </Animated.View>
+    </View>
+  )
+}
+
+export default BlogReadingView

--- a/src/screens/blogs/BlogDetatails.screen.tsx/BlogTitle.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/BlogTitle.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { StyleProp, TextStyle } from 'react-native'
+
+import tw from 'lib/tailwind'
+import Text from 'components/Text'
+
+interface Props {
+  title: string
+  color?: string
+  numberOfLines?: number
+  style?: StyleProp<TextStyle>
+}
+
+const BlogTitle: React.FC<Props> = ({
+  title,
+  color = '#FFFFFF',
+  numberOfLines = 2,
+  style,
+}) => (
+  <Text
+    style={[tw`text-3xl font-syne-bold`, { color }, style]}
+    numberOfLines={numberOfLines}
+    ellipsizeMode="tail"
+  >
+    {title}
+  </Text>
+)
+
+export default BlogTitle

--- a/src/screens/blogs/BlogDetatails.screen.tsx/Body.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/Body.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ScrollView, useWindowDimensions } from 'react-native'
+import { View, useWindowDimensions } from 'react-native'
 
 import tw from 'lib/tailwind'
 import { Blog } from '../../../../types'
@@ -9,20 +9,17 @@ type Props = {
   blog: Blog
 }
 
-const BlogDetailScreen: React.FC<Props> = ({ blog }) => {
+const Body: React.FC<Props> = ({ blog }) => {
   const { width } = useWindowDimensions()
   return (
-    <ScrollView
-      style={tw`dark:bg-gray-900 px-2`}
-      showsVerticalScrollIndicator={false}
-    >
+    <View style={tw`px-4`}>
       <RenderHtml
-        contentWidth={width}
+        contentWidth={width - 32}
         source={{ html: blog.content }}
         baseStyle={tw``}
       />
-    </ScrollView>
+    </View>
   )
 }
 
-export default BlogDetailScreen
+export default Body

--- a/src/screens/blogs/BlogDetatails.screen.tsx/Body.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/Body.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { ScrollView, useWindowDimensions } from 'react-native'
 
 import tw from 'lib/tailwind'
-import Text from 'components/Text'
 import { Blog } from '../../../../types'
 import RenderHtml from 'react-native-render-html'
 
@@ -14,11 +13,9 @@ const BlogDetailScreen: React.FC<Props> = ({ blog }) => {
   const { width } = useWindowDimensions()
   return (
     <ScrollView
-      style={tw`flex- bg-white dark:bg-gray-900 px-2`}
+      style={tw`dark:bg-gray-900 px-2`}
       showsVerticalScrollIndicator={false}
     >
-      <Text style={tw`text-2xl font-bold dark:text-white `}>{blog.title}</Text>
-
       <RenderHtml
         contentWidth={width}
         source={{ html: blog.content }}

--- a/src/screens/blogs/BlogDetatails.screen.tsx/HeroActionBar.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/HeroActionBar.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { View, TouchableOpacity } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+
+import tw from 'lib/tailwind'
+import Text from 'components/Text'
+import { colors } from 'components/ui/tokens'
+
+export const FLOAT_SURFACE = 'rgba(255,255,255,0.18)'
+
+interface Props {
+  onClose?: () => void
+  onMenu?: () => void
+  isDraft?: boolean
+  canEdit?: boolean
+}
+
+const HeroActionBar = ({ onClose, onMenu, isDraft, canEdit }: Props) => (
+  <View style={tw`flex-row items-center justify-between`}>
+    <View style={tw`flex-row items-center`}>
+      <TouchableOpacity
+        onPress={onClose}
+        activeOpacity={0.85}
+        style={[
+          tw`w-9 h-9 rounded-full items-center justify-center border border-white/30`,
+          { backgroundColor: FLOAT_SURFACE },
+        ]}
+      >
+        <Ionicons name="chevron-back" size={20} color="#FFFFFF" />
+      </TouchableOpacity>
+
+      {isDraft && (
+        <View
+          style={[
+            tw`ml-2 px-2.5 py-1 rounded-full`,
+            { backgroundColor: colors.amberSoft },
+          ]}
+        >
+          <Text
+            style={[tw`font-poppins-bold text-xs`, { color: colors.amberDeep }]}
+          >
+            Draft
+          </Text>
+        </View>
+      )}
+    </View>
+
+    {canEdit && (
+      <TouchableOpacity
+        onPress={onMenu}
+        activeOpacity={0.85}
+        style={[
+          tw`w-9 h-9 rounded-full items-center justify-center border border-white/30`,
+          { backgroundColor: FLOAT_SURFACE },
+        ]}
+      >
+        <Ionicons name="ellipsis-horizontal" size={18} color="#FFFFFF" />
+      </TouchableOpacity>
+    )}
+  </View>
+)
+
+export default HeroActionBar

--- a/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
@@ -6,15 +6,15 @@ import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import Screen from 'components/screen'
 import { FeedStackParams } from '../../../../types'
-// import Header from './Header'
-import CoverHero from '../CreateBlog.screen/BlogContent/CoverHero'
-import Body from './Body'
 import useToggle from 'hooks/useToggle'
 import Comment from './Comment'
-import { useFetchBlogQuery } from 'store/blog-api-slice'
-import HeroActionBar from './HeroActionBar'
+import BlogHero from './BlogHero'
 import BlogMetaBar from './BlogMetaBar'
-import { useToggleBlogLikeMutation } from '../../../store/blog-api-slice'
+import BlogReadingView from './BlogReadingView'
+import {
+  useFetchBlogQuery,
+  useToggleBlogLikeMutation,
+} from 'store/blog-api-slice'
 
 type Props = StackScreenProps<FeedStackParams, 'BlogDetail'>
 
@@ -40,33 +40,26 @@ const BlogDetailScreen: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <Screen safeArea={false} loading={isLoading || isFetching}>
-      <CoverHero
-        coverImage={blog.titlePicture}
-        interests={blog.interests || []}
-        headerComponent={
-          <HeroActionBar
-            onClose={() => navigation.goBack()}
-            onMenu={() => {}}
-            isDraft={false}
+      {content ? (
+        <BlogReadingView
+          blog={blog}
+          content={content}
+          onToggle={showContent}
+          onLike={handleLike}
+          onClose={() => navigation.goBack()}
+        />
+      ) : (
+        <>
+          <BlogHero blog={blog} onClose={() => navigation.goBack()} />
+          <BlogMetaBar
+            blog={blog}
+            content={content}
+            onToggle={showContent}
+            onLike={handleLike}
           />
-        }
-        titleComponent={
-          <Text
-            style={tw`text-3xl font-syne-bold text-white`}
-            numberOfLines={2}
-            ellipsizeMode="tail"
-          >
-            {blog.title}
-          </Text>
-        }
-      />
-      <BlogMetaBar
-        blog={blog}
-        content={content}
-        onToggle={showContent}
-        onLike={handleLike}
-      />
-      {content ? <Body blog={blog} /> : <Comment blogId={blogId} />}
+          <Comment blogId={blogId} />
+        </>
+      )}
     </Screen>
   )
 }

--- a/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
@@ -1,25 +1,32 @@
 import React from 'react'
-import { View, ScrollView, TouchableOpacity } from 'react-native'
+import { View } from 'react-native'
 import { StackScreenProps } from '@react-navigation/stack'
 
 import tw from 'lib/tailwind'
 import Text from 'components/Text'
 import Screen from 'components/screen'
 import { FeedStackParams } from '../../../../types'
-import Header from './Header'
+// import Header from './Header'
+import CoverHero from '../CreateBlog.screen/BlogContent/CoverHero'
 import Body from './Body'
 import useToggle from 'hooks/useToggle'
 import Comment from './Comment'
 import { useFetchBlogQuery } from 'store/blog-api-slice'
+import HeroActionBar from './HeroActionBar'
+import BlogMetaBar from './BlogMetaBar'
+import { useToggleBlogLikeMutation } from '../../../store/blog-api-slice'
 
 type Props = StackScreenProps<FeedStackParams, 'BlogDetail'>
 
 const BlogDetailScreen: React.FC<Props> = ({ route, navigation }) => {
   const { blogId } = route.params
-
   const { data: blog, isLoading, isFetching } = useFetchBlogQuery(blogId)
-
   const [content, showContent] = useToggle(true)
+  const [toggleBlogLike] = useToggleBlogLikeMutation()
+
+  const handleLike = async (id: string) => {
+    await toggleBlogLike(id).unwrap()
+  }
 
   if (!blog) {
     return (
@@ -33,7 +40,32 @@ const BlogDetailScreen: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <Screen safeArea={false} loading={isLoading || isFetching}>
-      <Header blog={blog} showContent={content} onShowContent={showContent} />
+      <CoverHero
+        coverImage={blog.titlePicture}
+        interests={blog.interests || []}
+        headerComponent={
+          <HeroActionBar
+            onClose={() => navigation.goBack()}
+            onMenu={() => {}}
+            isDraft={false}
+          />
+        }
+        titleComponent={
+          <Text
+            style={tw`text-3xl font-syne-bold text-white`}
+            numberOfLines={2}
+            ellipsizeMode="tail"
+          >
+            {blog.title}
+          </Text>
+        }
+      />
+      <BlogMetaBar
+        blog={blog}
+        content={content}
+        onToggle={showContent}
+        onLike={handleLike}
+      />
       {content ? <Body blog={blog} /> : <Comment blogId={blogId} />}
     </Screen>
   )

--- a/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
+++ b/src/screens/blogs/BlogDetatails.screen.tsx/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { View } from 'react-native'
 import { StackScreenProps } from '@react-navigation/stack'
+import Animated, { FadeInUp } from 'react-native-reanimated'
 
 import tw from 'lib/tailwind'
 import Text from 'components/Text'
@@ -22,6 +23,7 @@ const BlogDetailScreen: React.FC<Props> = ({ route, navigation }) => {
   const { blogId } = route.params
   const { data: blog, isLoading, isFetching } = useFetchBlogQuery(blogId)
   const [content, showContent] = useToggle(true)
+  const heroWasCollapsed = useRef(false)
   const [toggleBlogLike] = useToggleBlogLikeMutation()
 
   const handleLike = async (id: string) => {
@@ -44,13 +46,22 @@ const BlogDetailScreen: React.FC<Props> = ({ route, navigation }) => {
         <BlogReadingView
           blog={blog}
           content={content}
-          onToggle={showContent}
+          onToggle={(heroCollapsed) => {
+            heroWasCollapsed.current = heroCollapsed
+            showContent()
+          }}
           onLike={handleLike}
           onClose={() => navigation.goBack()}
         />
       ) : (
         <>
-          <BlogHero blog={blog} onClose={() => navigation.goBack()} />
+          <Animated.View
+            entering={
+              heroWasCollapsed.current ? FadeInUp.duration(400) : undefined
+            }
+          >
+            <BlogHero blog={blog} onClose={() => navigation.goBack()} />
+          </Animated.View>
           <BlogMetaBar
             blog={blog}
             content={content}

--- a/src/screens/blogs/CreateBlog.screen/BlogContent/CoverHero.tsx
+++ b/src/screens/blogs/CreateBlog.screen/BlogContent/CoverHero.tsx
@@ -6,9 +6,8 @@ import { LinearGradient } from 'expo-linear-gradient'
 
 import tw from 'lib/tailwind'
 import Text from 'components/Text'
-import HeroActionBar from './HeroActionBar'
 import InterestPills from './InterestPills'
-import TitleField from './TitleField'
+
 import CoverCornerButton from './CoverCornerButton'
 
 interface InterestLike {
@@ -19,25 +18,19 @@ interface InterestLike {
 interface Props {
   coverImage?: string
   interests?: InterestLike[]
-  onClose?: () => void
-  onSave?: () => void
-  onMenu?: () => void
   onChangeCover?: () => void
   onAddInterests?: () => void
-  isSubmitting?: boolean
-  isDraft?: boolean
+  headerComponent: React.ReactNode
+  titleComponent: React.ReactNode
 }
 
 const CoverHero = ({
   coverImage,
   interests,
-  onClose,
-  onSave,
-  onMenu,
   onChangeCover,
   onAddInterests,
-  isSubmitting,
-  isDraft,
+  headerComponent: HeaderComponent,
+  titleComponent: TitleComponent,
 }: Props) => {
   const hasInterests = !!interests && interests.length > 0
 
@@ -53,13 +46,7 @@ const CoverHero = ({
         style={tw`flex-1 px-4 pb-2`}
       >
         <SafeAreaView style={tw`flex-1`}>
-          <HeroActionBar
-            onClose={onClose}
-            onSave={onSave}
-            onMenu={onMenu}
-            isSubmitting={isSubmitting}
-            isDraft={isDraft}
-          />
+          {HeaderComponent}
 
           {!coverImage && onChangeCover && (
             <TouchableOpacity
@@ -94,7 +81,7 @@ const CoverHero = ({
               </TouchableOpacity>
             ) : null}
             <View style={{ height: 92, justifyContent: 'flex-end' }}>
-              <TitleField light />
+              {TitleComponent}
             </View>
           </View>
         </SafeAreaView>

--- a/src/screens/blogs/CreateBlog.screen/BlogContent/CoverHero.tsx
+++ b/src/screens/blogs/CreateBlog.screen/BlogContent/CoverHero.tsx
@@ -10,6 +10,8 @@ import InterestPills from './InterestPills'
 
 import CoverCornerButton from './CoverCornerButton'
 
+export const HERO_HEIGHT = 300
+
 interface InterestLike {
   id: string | number
   name: string
@@ -37,7 +39,7 @@ const CoverHero = ({
   return (
     <ImageBackground
       source={coverImage ? { uri: coverImage } : undefined}
-      style={[tw`w-full`, { height: 300 }]}
+      style={[tw`w-full`, { height: HERO_HEIGHT }]}
     >
       <LinearGradient
         colors={['rgba(27,31,94,0.55)', 'rgba(27,31,94,0.92)']}

--- a/src/screens/blogs/CreateBlog.screen/BlogContent/index.tsx
+++ b/src/screens/blogs/CreateBlog.screen/BlogContent/index.tsx
@@ -15,6 +15,8 @@ import CoverHero from './CoverHero'
 import WordCountBar from './WordCountBar'
 import OverflowMenu from './OverflowMenu'
 import ManageInterestsSheet from './ManageInterestsSheet'
+import HeroActionBar from './HeroActionBar'
+import TitleField from './TitleField'
 
 interface BlogContentProps {
   formRef?: React.Ref<FormikProps<BlogFormValues>>
@@ -93,15 +95,20 @@ const BlogContent: React.FC<BlogContentProps> = ({
           <CoverHero
             coverImage={coverImage}
             interests={selectedInterests}
-            onClose={onClose}
-            onSave={handlePublish}
-            onMenu={() => setMenuOpen(true)}
             onChangeCover={onCoverChange ? changeCover : undefined}
             onAddInterests={
               onInterestsChange ? () => setInterestsOpen(true) : undefined
             }
-            isSubmitting={isSubmitting}
-            isDraft={isDraft}
+            titleComponent={<TitleField light />}
+            headerComponent={
+              <HeroActionBar
+                onClose={onClose}
+                onSave={handlePublish}
+                onMenu={() => setMenuOpen(true)}
+                isSubmitting={isSubmitting}
+                isDraft={isDraft}
+              />
+            }
           />
           <RichTextEditor
             name="content"

--- a/types.d.ts
+++ b/types.d.ts
@@ -337,6 +337,7 @@ export interface Blog {
   content: string
   interests: Interest[]
   amountOfLikes: number
+  amountOfComments?: number
   createdAt: string
   publishedAt: string | null
   updatedAt: string


### PR DESCRIPTION
## Summary

Redesigns the single-blog **reading** screen (VWA-154), reusing the create/writing components from VWA-100/101. Base: `qa/cycle-38`.

## What's new

**Reusable cover hero**
- The reading screen now uses the same `CoverHero` as the writing screen (cover image + indigo gradient + interest pills). `CoverHero` was generalized to inject a `headerComponent` and `titleComponent`, so create (editable title + action bar) and read (static title + back/menu) share it. Exposes `HERO_HEIGHT`.
- `BlogHero` composes it for reading; `BlogTitle` is a shared title component (fixed Syne size, changeable `color`, bounded lines) used by both the hero and the collapsed header.

**Collapsing hero on scroll (Reanimated 3)**
- Content view lives in one `Animated.ScrollView` (hero → meta → body). Scrolling up fades/parallaxes the hero away and slides in a **sticky compact header** (back + meta + one-line title); scrolling down reverses it. Tunable `COLLAPSE_DISTANCE`.
- The inline meta bar fades out before the sticky one fades in, so the two are never shown together.

**Comment-switch animation**
- Toggling to the comments view animates the cover back in **only if it had collapsed** in the reading view (collapse state reported at toggle time; gated entrance).

**Modernized meta bar**
- `BlogMetaBar` shows author + `date · N min read` (read time via the reused `getReadingStats`), likes, and a rounded `primary-soft` comments/read toggle.

**Refactors / fixes**
- `Body` no longer owns a `ScrollView` (composes in the parent scroller).
- Extracted `BlogMetaBar`, `BlogTitle`, `BlogHero`, `BlogReadingView`.
- Added `amountOfComments?` to the `Blog` type.

## Scope
- Collapse applies to the **content** view; the Comments `FlatList` keeps a static header (follow-up).

## Test plan
- Open a blog: cover hero + interest pills + Syne title; scroll → hero collapses to sticky meta+title, scroll back → returns; long titles truncate (2 lines hero / 1 line sticky).
- Meta bar shows `date · N min read`, likes, and the toggle; tapping toggles article ↔ comments.
- Scroll content so hero vanishes → switch to comments → cover animates back in. Switch while near top → no entrance.
- Comments view renders with a static hero (no collapse).